### PR TITLE
hotfix: sqlite mkdir + GATEWAY_DB_PATH

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,7 +88,11 @@ func Load() (Config, error) {
 			ListenAddr: strings.TrimSpace(getEnv("API_PORT", ":8080")),
 		},
 		SQLite: SQLiteConfig{
-			Path: strings.TrimSpace(getEnv("SQLITE_PATH", "./gateway.db")),
+			// GATEWAY_DB_PATH is preferred in Docker (/app/data/gateway.db); SQLITE_PATH is the legacy name.
+			Path: firstNonEmpty(
+				strings.TrimSpace(os.Getenv("GATEWAY_DB_PATH")),
+				strings.TrimSpace(getEnv("SQLITE_PATH", "./gateway.db")),
+			),
 		},
 		MSSQL: MSSQLConfig{
 			Server:   strings.TrimSpace(os.Getenv("DB_SERVER")),
@@ -208,6 +212,13 @@ func getEnv(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func firstNonEmpty(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return a
+	}
+	return b
 }
 
 func mustDuration(s string) time.Duration {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -4,12 +4,22 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	_ "modernc.org/sqlite"
 )
 
 func OpenSQLite(path string) (*sql.DB, error) {
+	if path == "" {
+		return nil, fmt.Errorf("sqlite: database path is empty (set GATEWAY_DB_PATH or SQLITE_PATH)")
+	}
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("sqlite: create directory %q: %w", dir, err)
+		}
+	}
 	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)", path)
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {

--- a/tools/schemadiag/main.go
+++ b/tools/schemadiag/main.go
@@ -1,0 +1,85 @@
+// schemadiag runs read-only Medialog INFORMATION_SCHEMA probes (birth-related columns).
+// go run ./tools/schemadiag
+//
+// Prints one JSON object to stdout: pat_date_columns, patients_columns, errors.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/config"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/db"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "config:", err)
+		os.Exit(1)
+	}
+	m, err := db.OpenMSSQL(cfg.MSSQL)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mssql:", err)
+		os.Exit(1)
+	}
+	defer m.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	out := make(map[string]any)
+
+	rows, err := m.QueryContext(ctx, `
+SELECT t.TABLE_NAME, c.COLUMN_NAME, c.DATA_TYPE
+FROM INFORMATION_SCHEMA.TABLES t
+JOIN INFORMATION_SCHEMA.COLUMNS c ON c.TABLE_NAME = t.TABLE_NAME AND c.TABLE_SCHEMA = t.TABLE_SCHEMA
+WHERE t.TABLE_TYPE = 'BASE TABLE'
+  AND t.TABLE_NAME LIKE '%PAT%'
+  AND c.DATA_TYPE IN ('date','datetime','datetime2','smalldatetime')
+ORDER BY t.TABLE_NAME, c.COLUMN_NAME`)
+	if err != nil {
+		out["pat_date_columns_error"] = err.Error()
+	} else {
+		var list []map[string]string
+		for rows.Next() {
+			var table, col, typ string
+			_ = rows.Scan(&table, &col, &typ)
+			list = append(list, map[string]string{"table_name": table, "column_name": col, "data_type": typ})
+		}
+		_ = rows.Close()
+		out["pat_date_columns"] = list
+	}
+
+	rows, err = m.QueryContext(ctx, `
+SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_NAME = 'PATIENTS'
+ORDER BY ORDINAL_POSITION`)
+	if err != nil {
+		out["patients_columns_error"] = err.Error()
+	} else {
+		var plist []map[string]any
+		for rows.Next() {
+			var name, dtype string
+			var maxlen sql.NullInt64
+			_ = rows.Scan(&name, &dtype, &maxlen)
+			row := map[string]any{"column_name": name, "data_type": dtype}
+			if maxlen.Valid {
+				row["character_maximum_length"] = maxlen.Int64
+			} else {
+				row["character_maximum_length"] = nil
+			}
+			plist = append(plist, row)
+		}
+		_ = rows.Close()
+		out["patients_columns"] = plist
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(out)
+}


### PR DESCRIPTION
Чинит рестарт-луп api-gateway на dev-стенде после деплоя шага 2.

Два изменения:
1. В internal/db/sqlite.go перед sql.Open добавлен os.MkdirAll(filepath.Dir(path), 0755) — аналог того, что есть в max-bot/storage.go.
2. В config читается GATEWAY_DB_PATH (с fallback на SQLITE_PATH → ./gateway.db).

Плюс tools/schemadiag — утилита для ad-hoc SQL-выборок по схеме Medialog (пригодилась для поиска NE_LE, останется для будущих миграций).

## Требуется после merge

1. В **medkvadrat-deploy** уже смержено ([ffeb602](https://github.com/Ramses994/medkvadrat-deploy/commit/ffeb602)):
   - volume `gateway-data` → `/app/data`
   - env `GATEWAY_DB_PATH=/app/data/gateway.db`
   - блоки env для `JWT_SECRET`, `OTP_HMAC_SECRET`, `AUTH_MODE`, `SMTP_*`

2. **Действия администратора на dev-стенде** после merge этого PR:
   - `git pull` в рабочей директории runner'а для `medkvadrat-deploy`
   - дополнить `.env` новыми переменными из `.env.example`
   - `openssl rand -hex 32` → `JWT_SECRET`
   - `openssl rand -hex 32` → `OTP_HMAC_SECRET`
   - `docker compose pull api-gateway`
   - `docker compose up -d api-gateway`
   - проверить: `docker compose logs api-gateway --tail=50` — ни одного ERROR; должно быть «sqlite connected» и «listening on :8080».
