### PR TITLE
fix(me): avoid transaction abort by clinic triggers

### DIFF
--- a/internal/integration/booking_concurrency_test.go
+++ b/internal/integration/booking_concurrency_test.go
@@ -18,13 +18,16 @@ import (
 )
 
 // Concurrency: 10 different patients race for one free planning row.
-// Expect: exactly 1 success; others get SLOT_TAKEN (or ALREADY_BOOKED if a patient is duplicated — we use distinct patients).
+// Expect: exactly 1 success; losers should fail (slot taken, etc).
+// Note: CreateMotconsu is a clinic-side SP and may create rows even for losers;
+// production code compensates by marking them REC_STATUS='D'. This test is here
+// to catch race conditions, not to assert exact side effects in Medialog.
 // Requires a live Medialog MSSQL; point env DB_* to it (e.g. dev) or a local
 //
 //	docker run: mcr.microsoft.com/mssql/server:2022-latest
 //
 //	go test -tags=integration ./internal/integration/...
-func TestBookMe_SerializableConcurrent(t *testing.T) {
+func TestBookMe_ConcurrentRace(t *testing.T) {
 	if os.Getenv("INTEGRATION_MSSQL") == "" {
 		t.Skip("set INTEGRATION_MSSQL=1 and DB_* to run")
 	}

--- a/internal/integration/me_book_cancel_smoke_test.go
+++ b/internal/integration/me_book_cancel_smoke_test.go
@@ -1,0 +1,118 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/denisenkom/go-mssqldb"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/config"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/db"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/repo"
+)
+
+// End-to-end DB-level smoke for Medialog write path (book + cancel).
+// IMPORTANT: this test touches real Medialog tables. It best-effort cleans up.
+//
+// Run:
+//   INTEGRATION_MSSQL=1 go test -tags=integration ./internal/integration/...
+func TestBookMeAndCancelMe_RealMSSQL(t *testing.T) {
+	if os.Getenv("INTEGRATION_MSSQL") == "" {
+		t.Skip("set INTEGRATION_MSSQL=1 and DB_* to run")
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	mssql, err := db.OpenMSSQL(cfg.MSSQL)
+	if err != nil {
+		t.Fatalf("mssql: %v", err)
+	}
+	t.Cleanup(func() { _ = mssql.Close() })
+
+	ctx := context.Background()
+
+	// Pick any free slot (we only need the ID; details are read from PLANNING).
+	var planningID int
+	if err := mssql.QueryRowContext(ctx, `
+SELECT TOP 1 p.PLANNING_ID
+FROM PLANNING p
+WHERE p.PATIENTS_ID IS NULL
+  AND p.STATUS = 0
+  AND p.DATE_CONS >= CAST(GETDATE() AS date)
+ORDER BY p.DATE_CONS, p.HEURE`).Scan(&planningID); err != nil {
+		t.Fatalf("pick planning: %v", err)
+	}
+	if planningID == 0 {
+		t.Fatal("no free planning row found")
+	}
+
+	// Pick a patient (any existing patient row).
+	var patientID int64
+	if err := mssql.QueryRowContext(ctx, `SELECT TOP 1 PATIENTS_ID FROM PATIENTS ORDER BY PATIENTS_ID`).Scan(&patientID); err != nil {
+		t.Fatalf("pick patient: %v", err)
+	}
+	if patientID == 0 {
+		t.Fatal("no patient row found")
+	}
+
+	plan := &repo.PlanningRepo{}
+	mot := &repo.MotconsuRepo{}
+
+	// Book.
+	now := time.Now()
+	got, err := repo.BookMe(ctx, mssql, plan, mot, planningID, patientID, 306, now)
+	if err != nil {
+		t.Fatalf("BookMe: %v", err)
+	}
+	if got.MotconsuID == 0 {
+		t.Fatalf("BookMe: motconsu_id=0")
+	}
+
+	// Verify DB side effects.
+	var motPlanning sql.NullInt64
+	var recStatus string
+	if err := mssql.QueryRowContext(ctx, `
+SELECT PLANNING_ID, ISNULL(REC_STATUS,'')
+FROM MOTCONSU
+WHERE MOTCONSU_ID=@id`, sql.Named("id", got.MotconsuID)).Scan(&motPlanning, &recStatus); err != nil {
+		t.Fatalf("select motconsu: %v", err)
+	}
+	if !motPlanning.Valid || int(motPlanning.Int64) != planningID {
+		t.Fatalf("motconsu planning mismatch: got %v, want %d", motPlanning, planningID)
+	}
+	if recStatus != "W" {
+		t.Fatalf("motconsu status: got %q, want %q", recStatus, "W")
+	}
+	var planningPat sql.NullInt64
+	if err := mssql.QueryRowContext(ctx, `SELECT PATIENTS_ID FROM PLANNING WHERE PLANNING_ID=@id`, sql.Named("id", planningID)).Scan(&planningPat); err != nil {
+		t.Fatalf("select planning: %v", err)
+	}
+	if !planningPat.Valid || planningPat.Int64 != patientID {
+		t.Fatalf("planning patients_id: got %v, want %d", planningPat, patientID)
+	}
+
+	// Cancel. We bypass 24h rule by passing 0 in repo function.
+	if err := repo.CancelMe(ctx, mssql, got.MotconsuID, patientID, 0, now); err != nil {
+		t.Fatalf("CancelMe: %v", err)
+	}
+	if err := mssql.QueryRowContext(ctx, `
+SELECT ISNULL(REC_STATUS,'')
+FROM MOTCONSU WHERE MOTCONSU_ID=@id`, sql.Named("id", got.MotconsuID)).Scan(&recStatus); err != nil {
+		t.Fatalf("select motconsu status after cancel: %v", err)
+	}
+	if recStatus != "D" {
+		t.Fatalf("motconsu status after cancel: got %q, want %q", recStatus, "D")
+	}
+
+	// Best-effort cleanup for dev DB idempotency.
+	_, _ = mssql.ExecContext(ctx, `
+UPDATE PLANNING SET PATIENTS_ID=NULL, NOM=NULL, PRENOM=NULL
+WHERE PLANNING_ID=@id AND PATIENTS_ID=@pat`, sql.Named("id", planningID), sql.Named("pat", patientID))
+}
+

--- a/internal/repo/booking_me.go
+++ b/internal/repo/booking_me.go
@@ -13,21 +13,17 @@ type BookMeResult struct {
 }
 
 func BookMe(ctx context.Context, db *sql.DB, planning *PlanningRepo, motconsu *MotconsuRepo, planningID int, patientID int64, defaultModelsID int, now time.Time) (BookMeResult, error) {
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
-	if err != nil {
-		return BookMeResult{}, fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-
-	// Lock + read slot (allow already held by same patient).
+	// Important: do NOT wrap clinic-side CreateMotconsu SP into our own transaction.
+	// Some installations have triggers that abort the outer transaction.
+	// Read slot (allow already held by same patient).
 	var plSubjID int
 	var dateCons time.Time
 	var heure int
 	var duree int
 	var slotPat sql.NullInt64
-	if err := tx.QueryRowContext(ctx, `
+	if err := db.QueryRowContext(ctx, `
 SELECT PL_SUBJ_ID, DATE_CONS, HEURE, DUREE, PATIENTS_ID
-FROM PLANNING WITH (UPDLOCK, ROWLOCK)
+FROM PLANNING
 WHERE PLANNING_ID = @id`,
 		sql.Named("id", planningID),
 	).Scan(&plSubjID, &dateCons, &heure, &duree, &slotPat); err != nil {
@@ -46,7 +42,7 @@ WHERE PLANNING_ID = @id`,
 	// Existing appointment?
 	var existingID sql.NullInt64
 	var existingStatus sql.NullString
-	_ = tx.QueryRowContext(ctx, `
+	_ = db.QueryRowContext(ctx, `
 SELECT TOP 1 MOTCONSU_ID, REC_STATUS
 FROM MOTCONSU
 WHERE PLANNING_ID = @pid AND PATIENTS_ID = @pat
@@ -58,15 +54,18 @@ ORDER BY MOTCONSU_ID DESC`,
 	if existingID.Valid && existingStatus.Valid {
 		switch existingStatus.String {
 		case "D":
-			if _, err := tx.ExecContext(ctx, `
+			res, err := db.ExecContext(ctx, `
 UPDATE MOTCONSU SET REC_STATUS='W', KRN_MODIFY_DATE=GETDATE()
-WHERE MOTCONSU_ID=@id`,
+WHERE MOTCONSU_ID=@id AND PATIENTS_ID=@pat AND REC_STATUS='D'`,
 				sql.Named("id", existingID.Int64),
+				sql.Named("pat", patientID),
 			); err != nil {
 				return BookMeResult{}, fmt.Errorf("restore motconsu: %w", err)
 			}
-			if err := tx.Commit(); err != nil {
-				return BookMeResult{}, fmt.Errorf("commit: %w", err)
+			ra, _ := res.RowsAffected()
+			if ra == 0 {
+				// Someone changed status between our read and restore.
+				return BookMeResult{}, fmt.Errorf("ALREADY_BOOKED")
 			}
 			return BookMeResult{MotconsuID: existingID.Int64, Restored: true}, nil
 		case "W":
@@ -77,7 +76,7 @@ WHERE MOTCONSU_ID=@id`,
 	// Determine doctor + dep data from slot.
 	var medecinsID, fmDepID int
 	var meddepID sql.NullInt64
-	if err := tx.QueryRowContext(ctx, `
+	if err := db.QueryRowContext(ctx, `
 SELECT ps.MEDECINS_ID,
   ISNULL((SELECT FM_DEP_ID FROM MEDDEP WHERE MEDDEP_ID = ps.MEDDEP_ID), 0),
   ps.MEDDEP_ID
@@ -97,12 +96,12 @@ FROM PL_SUBJ ps WHERE ps.PL_SUBJ_ID = @id`,
 	}
 
 	var patNom, patPrenom string
-	_ = tx.QueryRowContext(ctx, `SELECT ISNULL(NOM,''), ISNULL(PRENOM,'') FROM PATIENTS WHERE PATIENTS_ID=@id`,
+	_ = db.QueryRowContext(ctx, `SELECT ISNULL(NOM,''), ISNULL(PRENOM,'') FROM PATIENTS WHERE PATIENTS_ID=@id`,
 		sql.Named("id", patientID),
 	).Scan(&patNom, &patPrenom)
 
 	var motconsuID int
-	if err := tx.QueryRowContext(ctx, `
+	if err := db.QueryRowContext(ctx, `
 DECLARE @NewID int = 0;
 EXEC CreateMotconsu
   @PatientID = @patID, @ModelsID = @modID,
@@ -123,34 +122,57 @@ SELECT @NewID;`,
 	}
 
 	if !slotPat.Valid {
-		if err := planning.FillSlot(tx, ctx, planningID, int(patientID), patNom, patPrenom); err != nil {
+		// Guarded UPDATE: either we fill the slot, or someone else already did.
+		res, err := db.ExecContext(ctx, `
+UPDATE PLANNING
+SET PATIENTS_ID=@patID, NOM=@nom, PRENOM=@prenom
+WHERE PLANNING_ID=@planID AND PATIENTS_ID IS NULL`,
+			sql.Named("patID", patientID),
+			sql.Named("nom", patNom),
+			sql.Named("prenom", patPrenom),
+			sql.Named("planID", planningID),
+		)
+		if err != nil {
 			return BookMeResult{}, fmt.Errorf("update planning: %w", err)
 		}
+		ra, _ := res.RowsAffected()
+		if ra == 0 {
+			// Compensate: booking row exists, but slot was taken concurrently.
+			_, _ = db.ExecContext(ctx, `
+UPDATE MOTCONSU SET REC_STATUS='D', KRN_MODIFY_DATE=GETDATE()
+WHERE MOTCONSU_ID=@id AND PATIENTS_ID=@pat`,
+				sql.Named("id", motconsuID),
+				sql.Named("pat", patientID),
+			)
+			return BookMeResult{}, fmt.Errorf("SLOT_TAKEN")
+		}
 	}
-	if err := motconsu.SetPlanningAndStatus(tx, ctx, motconsuID, planningID, "W"); err != nil {
+	res, err := db.ExecContext(ctx, `
+UPDATE MOTCONSU SET PLANNING_ID=@planID, REC_STATUS=@st
+WHERE MOTCONSU_ID=@motID AND PATIENTS_ID=@pat`,
+		sql.Named("planID", planningID),
+		sql.Named("st", "W"),
+		sql.Named("motID", motconsuID),
+		sql.Named("pat", patientID),
+	)
+	if err != nil {
 		return BookMeResult{}, fmt.Errorf("update motconsu: %w", err)
 	}
-
-	if err := tx.Commit(); err != nil {
-		return BookMeResult{}, fmt.Errorf("commit: %w", err)
+	ra, _ := res.RowsAffected()
+	if ra == 0 {
+		return BookMeResult{}, fmt.Errorf("update motconsu: %w", sql.ErrNoRows)
 	}
 	return BookMeResult{MotconsuID: int64(motconsuID)}, nil
 }
 
 func CancelMe(ctx context.Context, db *sql.DB, motconsuID int64, patientID int64, cancelMinBefore time.Duration, now time.Time) error {
-	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-
 	var patID int64
 	var dt time.Time
 	var st string
 	var planningID sql.NullInt64
-	err = tx.QueryRowContext(ctx, `
+	err := db.QueryRowContext(ctx, `
 SELECT PATIENTS_ID, DATE_CONSULTATION, ISNULL(REC_STATUS,''), PLANNING_ID
-FROM MOTCONSU WITH (UPDLOCK, ROWLOCK)
+FROM MOTCONSU
 WHERE MOTCONSU_ID=@id`,
 		sql.Named("id", motconsuID),
 	).Scan(&patID, &dt, &st, &planningID)
@@ -172,12 +194,17 @@ WHERE MOTCONSU_ID=@id`,
 	if dt.Before(now.Add(cancelMinBefore)) {
 		return fmt.Errorf("CANCEL_TOO_LATE")
 	}
-	if _, err := tx.ExecContext(ctx, `
+	res, err := db.ExecContext(ctx, `
 UPDATE MOTCONSU SET REC_STATUS='D', KRN_MODIFY_DATE=GETDATE()
-WHERE MOTCONSU_ID=@id`,
+WHERE MOTCONSU_ID=@id AND PATIENTS_ID=@pat AND REC_STATUS<>'D'`,
 		sql.Named("id", motconsuID),
+		sql.Named("pat", patientID),
 	); err != nil {
 		return fmt.Errorf("cancel: %w", err)
 	}
-	return tx.Commit()
+	ra, _ := res.RowsAffected()
+	if ra == 0 {
+		return fmt.Errorf("ALREADY_CANCELLED")
+	}
+	return nil
 }

--- a/internal/repo/booking_me.go
+++ b/internal/repo/booking_me.go
@@ -59,7 +59,8 @@ UPDATE MOTCONSU SET REC_STATUS='W', KRN_MODIFY_DATE=GETDATE()
 WHERE MOTCONSU_ID=@id AND PATIENTS_ID=@pat AND REC_STATUS='D'`,
 				sql.Named("id", existingID.Int64),
 				sql.Named("pat", patientID),
-			); err != nil {
+			)
+			if err != nil {
 				return BookMeResult{}, fmt.Errorf("restore motconsu: %w", err)
 			}
 			ra, _ := res.RowsAffected()
@@ -199,7 +200,8 @@ UPDATE MOTCONSU SET REC_STATUS='D', KRN_MODIFY_DATE=GETDATE()
 WHERE MOTCONSU_ID=@id AND PATIENTS_ID=@pat AND REC_STATUS<>'D'`,
 		sql.Named("id", motconsuID),
 		sql.Named("pat", patientID),
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("cancel: %w", err)
 	}
 	ra, _ := res.RowsAffected()


### PR DESCRIPTION
## Root cause\nНа реальной MSSQL клиники EXEC CreateMotconsu внутри нашей BEGIN TRAN (Serializable) падает: The transaction ended in the trigger. The batch has been aborted.\n\nПричина: clinic-side triggers на MOTCONSU/связанных таблицах (MOBIMED/HL7) могут делать rollback/abort, что убивает *внешнюю* транзакцию целиком.\n\n## Fix\n- Убрана внешняя BeginTx(Serializable) обёртка вокруг book/cancel.\n- Бронирование слота теперь через guarded UPDATE: UPDATE PLANNING ... WHERE PLANNING_ID=@id AND PATIENTS_ID IS NULL, проверка RowsAffected → если 0, то SLOT_TAKEN.\n- Если слот успели занять после CreateMotconsu, делаем best-effort компенсацию: помечаем созданный MOTCONSU как REC_STATUS='D'.\n- MOTCONSU связывается с PLANNING_ID и REC_STATUS='W' guarded по PATIENTS_ID.\n- Cancel — одиночный guarded UPDATE MOTCONSU (PLANNING не трогаем, как и было по политике клиники).\n\n## Tests\n- Обновлён concurrency integration test (теперь не привязан к Serializable).\n- Добавлен integration smoke TestBookMeAndCancelMe_RealMSSQL (//go:build integration) — проверяет side effects в Medialog и делает best-effort cleanup.\n\n> Локально на этой машине go test ./... не запускается из-за устаревшего Go toolchain (нет log/slog/slices). CI/окружение проекта должно запускаться на Go \u2265 1.22.