### PR TITLE
chore: add scripts/integration-test.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@ The script must be executable (`chmod +x scripts/dev-smoke.sh`). It exercises OT
 
 `GET /api/me/profile` exposes `birth_date` (`YYYY-MM-DD`) from Medialog `PATIENTS.NE_LE` when set, otherwise `birth_year` from `GOD_ROGDENIQ`. Clients should show one or the other, not both.
 
+## Integration tests (MSSQL)
+
+Integration tests verify behavior against a real dev MSSQL instance. They cover write paths (book/cancel/restore) that mocks can't simulate — clinic-side triggers and stored procedures.
+
+Prerequisites:
+- Docker installed.
+- `medkvadrat-internal` network exists (created by `docker compose up` on the deploy host).
+- `.env` with `DB_SERVER`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` (same as api-gateway).
+
+Run:
+
+```sh
+./scripts/integration-test.sh
+```
+
+The script runs `go test -tags=integration ./internal/integration/... -v` inside a throwaway `golang:1.22-alpine` container on `medkvadrat-internal` network and cleans up.
+
+Override network if running outside compose context:
+
+```sh
+DOCKER_NETWORK=host ./scripts/integration-test.sh
+```
+
+See also: `docs/MEDIALOG_RULES.md`.
+
 ## Ad-hoc SQL tools (Medialog read-only)
 
 From repo root with `.env` / env vars for MSSQL (same as the API):

--- a/docs/MEDIALOG_RULES.md
+++ b/docs/MEDIALOG_RULES.md
@@ -1,0 +1,41 @@
+# Правила работы с базой Medialog
+
+Medialog — продакшн‑БД клиники. Наша интеграция должна быть максимально “прозрачной” для клиники и совместимой с их триггерами/процедурами.
+
+## Запрещено без явного согласования с клиникой
+
+- Любые `ALTER/CREATE/DROP` (таблицы/индексы/триггеры/процедуры/функции) в Medialog.
+- Вносить изменения в HL7/MOBIMED служебные таблицы напрямую (если это не делает сама Medialog через свои SP/триггеры).
+- Оборачивать clinic-side stored procedures (например, `CreateMotconsu`) во внешнюю транзакцию из нашего кода. На реальных инсталляциях триггеры могут abort’ить outer transaction.
+- Поднимать уровень изоляции выше `READ COMMITTED` в пользовательском коде.
+- Использовать table hints (`UPDLOCK`, `HOLDLOCK`, `TABLOCK`, …) как способ “исправить гонки”.
+
+## Разрешено
+
+- `SELECT` для read-path’ов.
+- `EXEC` существующих clinic-side stored procedures (например, `CreateMotconsu`) **как контракт клиники**, без внешней транзакции.
+- Write‑логика сервиса (OTP/JWT/sessions/rate limit/напоминания) — в нашей SQLite (`gateway.db`), не в Medialog.
+
+## Паттерн “guarded UPDATE”
+
+Для конкуренции (гонок) используем атомарный UPDATE с предусловием:
+
+```sql
+UPDATE target
+SET ...
+WHERE id = @id AND <business_invariant>
+```
+
+Дальше проверяем `RowsAffected()`:
+- `1` — успех,
+- `0` — предусловие нарушено / слот уже занят → возвращаем `409 SLOT_TAKEN` или аналогичный бизнес‑код.
+
+## Integration‑тесты обязательны для Medialog write‑path
+
+Golden/unit тесты через моки **не ловят**:
+- триггеры,
+- поведение stored procedures,
+- реальные ограничения и побочные эффекты в MSSQL.
+
+Каждый write‑эндпоинт в Medialog должен иметь integration‑тест под build‑tag `integration` и прогоняться на dev MSSQL через `./scripts/integration-test.sh`.
+

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+if [ ! -f ".env" ]; then
+  echo "ERROR: .env not found in repo root." >&2
+  echo "Copy it next to this script (repo root), then re-run." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2046
+export $(grep -v '^[[:space:]]*#' .env | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' | xargs)
+
+NET="${DOCKER_NETWORK:-medkvadrat-internal}"
+if ! docker network inspect "${NET}" >/dev/null 2>&1; then
+  echo "ERROR: docker network '${NET}' not found." >&2
+  echo "Run this script on a host where api-gateway compose stack exists," >&2
+  echo "or override with DOCKER_NETWORK=host (less isolated)." >&2
+  exit 1
+fi
+
+for v in DB_SERVER DB_PORT DB_NAME DB_USER DB_PASSWORD; do
+  if [ -z "${!v:-}" ]; then
+    echo "ERROR: missing ${v} in .env" >&2
+    exit 1
+  fi
+done
+
+IMG="${GO_IMAGE:-golang:1.22-alpine}"
+
+echo "Running integration tests in ${IMG} on network ${NET}"
+echo "Repo: $(pwd)"
+
+docker run --rm \
+  --network "${NET}" \
+  -v "$(pwd)":/src -w /src \
+  -e INTEGRATION_MSSQL=1 \
+  -e DB_SERVER -e DB_PORT -e DB_NAME -e DB_USER -e DB_PASSWORD \
+  "${IMG}" \
+  sh -ceu '
+    apk add --no-cache git >/dev/null
+    go test -tags=integration ./internal/integration/... -v
+  '
+


### PR DESCRIPTION
Добавляет scripts/integration-test.sh (docker-runner для go test -tags=integration против dev MSSQL) + README раздел про integration + docs/MEDIALOG_RULES.md (процесс и запреты для Medialog write-path).