### PR TITLE
feat(api): POST /api/internal/confirmations

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -51,17 +51,12 @@ func NewRouter(cfg config.Config, svc *service.Services, logger *slog.Logger) ht
 	mux.HandleFunc("DELETE /api/me/appointments/{motconsu_id}", meH.CancelAppointment)
 	mux.HandleFunc("GET /api/me/lab-panels", meH.LabPanels)
 
-	// Internal (bot-only, INTERNAL_API_TOKEN)
+	// Server-to-server (API_TOKEN), same as /api/reminders/due
 	mux.HandleFunc("POST /api/internal/confirmations", confirmationsH.Upsert)
 
 	auth := middleware.Auth{Token: cfg.APIToken}
-	internalAuth := middleware.Auth{Token: cfg.InternalAPIToken}
 	reqPatient := middleware.RequirePatient{JWTSecret: []byte(cfg.JWT.Secret)}
 	var base http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/internal/") {
-			internalAuth.RequireBearer(mux).ServeHTTP(w, r)
-			return
-		}
 		if strings.HasPrefix(r.URL.Path, "/api/auth/") || r.URL.Path == "/api/health" {
 			mux.ServeHTTP(w, r)
 			return

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -21,6 +21,7 @@ func NewRouter(cfg config.Config, svc *service.Services, logger *slog.Logger) ht
 	scheduleH := handler.ScheduleHandler{Svc: svc, Logger: logger}
 	catalogH := handler.CatalogHandler{Svc: svc, Logger: logger}
 	meH := handler.MeHandler{Svc: svc, Logger: logger, CancelMinHours: cfg.CancelMinHoursBefore}
+	confirmationsH := handler.ConfirmationsHandler{Svc: svc, Logger: logger}
 
 	// Public
 	mux.HandleFunc("GET /api/health", healthH.Health)
@@ -50,9 +51,17 @@ func NewRouter(cfg config.Config, svc *service.Services, logger *slog.Logger) ht
 	mux.HandleFunc("DELETE /api/me/appointments/{motconsu_id}", meH.CancelAppointment)
 	mux.HandleFunc("GET /api/me/lab-panels", meH.LabPanels)
 
+	// Internal (bot-only, INTERNAL_API_TOKEN)
+	mux.HandleFunc("POST /api/internal/confirmations", confirmationsH.Upsert)
+
 	auth := middleware.Auth{Token: cfg.APIToken}
+	internalAuth := middleware.Auth{Token: cfg.InternalAPIToken}
 	reqPatient := middleware.RequirePatient{JWTSecret: []byte(cfg.JWT.Secret)}
 	var base http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/internal/") {
+			internalAuth.RequireBearer(mux).ServeHTTP(w, r)
+			return
+		}
 		if strings.HasPrefix(r.URL.Path, "/api/auth/") || r.URL.Path == "/api/health" {
 			mux.ServeHTTP(w, r)
 			return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,8 @@ import (
 type Config struct {
 	Env          string
 	LogLevel     string
-	APIToken     string
+	APIToken         string
+	InternalAPIToken string
 	PollInterval time.Duration
 	// CancelMinHoursBefore defines the minimum time before appointment start
 	// when patient cancellation is allowed.
@@ -86,6 +87,7 @@ func Load() (Config, error) {
 		Env:                  strings.TrimSpace(getEnv("ENV", "dev")),
 		LogLevel:             strings.TrimSpace(getEnv("LOG_LEVEL", "info")),
 		APIToken:             strings.TrimSpace(os.Getenv("API_TOKEN")),
+		InternalAPIToken:     strings.TrimSpace(os.Getenv("INTERNAL_API_TOKEN")),
 		PollInterval:         mustDuration(getEnv("POLL_INTERVAL", "5s")),
 		CancelMinHoursBefore: mustInt(getEnv("CANCEL_MIN_HOURS_BEFORE", "24"), 24),
 		HTTP: HTTPConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,6 @@ type Config struct {
 	Env          string
 	LogLevel     string
 	APIToken         string
-	InternalAPIToken string
 	PollInterval time.Duration
 	// CancelMinHoursBefore defines the minimum time before appointment start
 	// when patient cancellation is allowed.
@@ -87,7 +86,6 @@ func Load() (Config, error) {
 		Env:                  strings.TrimSpace(getEnv("ENV", "dev")),
 		LogLevel:             strings.TrimSpace(getEnv("LOG_LEVEL", "info")),
 		APIToken:             strings.TrimSpace(os.Getenv("API_TOKEN")),
-		InternalAPIToken:     strings.TrimSpace(os.Getenv("INTERNAL_API_TOKEN")),
 		PollInterval:         mustDuration(getEnv("POLL_INTERVAL", "5s")),
 		CancelMinHoursBefore: mustInt(getEnv("CANCEL_MIN_HOURS_BEFORE", "24"), 24),
 		HTTP: HTTPConfig{

--- a/internal/confirmations/errors.go
+++ b/internal/confirmations/errors.go
@@ -1,0 +1,8 @@
+package confirmations
+
+import "errors"
+
+var (
+	ErrAppointmentNotFound = errors.New("APPOINTMENT_NOT_FOUND")
+	ErrPatientMismatch     = errors.New("PATIENT_MISMATCH")
+)

--- a/internal/confirmations/repo.go
+++ b/internal/confirmations/repo.go
@@ -7,11 +7,11 @@ import (
 	"time"
 )
 
-const defaultSource = "max_bot"
+const defaultSource = "max"
 
 // Record is the persisted confirmation overlay in gateway.db.
 type Record struct {
-	MotconsuID int64
+	PlanningID int64
 	PatientID  int64
 	Status     string
 	Source     string
@@ -26,27 +26,27 @@ func NewRepo(db *sql.DB) *Repo {
 	return &Repo{db: db}
 }
 
-// Upsert stores confirmation with last-write-wins semantics per motconsu_id.
-func (r *Repo) Upsert(ctx context.Context, motconsuID, patientID int64, status, source string) (Record, error) {
+// Upsert stores confirmation with last-write-wins semantics per planning_id.
+func (r *Repo) Upsert(ctx context.Context, planningID, patientID int64, status, source string) (Record, error) {
 	if source == "" {
 		source = defaultSource
 	}
 	status = NormalizeStatus(status)
 
 	const q = `
-INSERT INTO appointment_confirmations (motconsu_id, patient_id, status, source, updated_at)
+INSERT INTO appointment_confirmations (planning_id, status, source, patient_id, updated_at)
 VALUES (?, ?, ?, ?, datetime('now'))
-ON CONFLICT(motconsu_id) DO UPDATE SET
-  patient_id = excluded.patient_id,
+ON CONFLICT(planning_id) DO UPDATE SET
   status = excluded.status,
   source = excluded.source,
+  patient_id = excluded.patient_id,
   updated_at = excluded.updated_at
-RETURNING motconsu_id, patient_id, status, source, updated_at`
+RETURNING planning_id, status, source, patient_id, updated_at`
 
 	var rec Record
 	var updatedAt string
-	err := r.db.QueryRowContext(ctx, q, motconsuID, patientID, status, source).Scan(
-		&rec.MotconsuID, &rec.PatientID, &rec.Status, &rec.Source, &updatedAt,
+	err := r.db.QueryRowContext(ctx, q, planningID, status, source, patientID).Scan(
+		&rec.PlanningID, &rec.Status, &rec.Source, &rec.PatientID, &updatedAt,
 	)
 	if err != nil {
 		return Record{}, fmt.Errorf("upsert confirmation: %w", err)

--- a/internal/confirmations/repo.go
+++ b/internal/confirmations/repo.go
@@ -1,0 +1,69 @@
+package confirmations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+const defaultSource = "max_bot"
+
+// Record is the persisted confirmation overlay in gateway.db.
+type Record struct {
+	MotconsuID int64
+	PatientID  int64
+	Status     string
+	Source     string
+	UpdatedAt  time.Time
+}
+
+type Repo struct {
+	db *sql.DB
+}
+
+func NewRepo(db *sql.DB) *Repo {
+	return &Repo{db: db}
+}
+
+// Upsert stores confirmation with last-write-wins semantics per motconsu_id.
+func (r *Repo) Upsert(ctx context.Context, motconsuID, patientID int64, status, source string) (Record, error) {
+	if source == "" {
+		source = defaultSource
+	}
+	status = NormalizeStatus(status)
+
+	const q = `
+INSERT INTO appointment_confirmations (motconsu_id, patient_id, status, source, updated_at)
+VALUES (?, ?, ?, ?, datetime('now'))
+ON CONFLICT(motconsu_id) DO UPDATE SET
+  patient_id = excluded.patient_id,
+  status = excluded.status,
+  source = excluded.source,
+  updated_at = excluded.updated_at
+RETURNING motconsu_id, patient_id, status, source, updated_at`
+
+	var rec Record
+	var updatedAt string
+	err := r.db.QueryRowContext(ctx, q, motconsuID, patientID, status, source).Scan(
+		&rec.MotconsuID, &rec.PatientID, &rec.Status, &rec.Source, &updatedAt,
+	)
+	if err != nil {
+		return Record{}, fmt.Errorf("upsert confirmation: %w", err)
+	}
+	t, err := parseSQLiteTime(updatedAt)
+	if err != nil {
+		return Record{}, err
+	}
+	rec.UpdatedAt = t
+	return rec, nil
+}
+
+func parseSQLiteTime(s string) (time.Time, error) {
+	for _, layout := range []string{"2006-01-02 15:04:05", time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("parse updated_at %q", s)
+}

--- a/internal/confirmations/repo_test.go
+++ b/internal/confirmations/repo_test.go
@@ -27,15 +27,15 @@ func TestRepo_UpsertLastWriteWins(t *testing.T) {
 	r := NewRepo(db)
 	ctx := context.Background()
 
-	rec, err := r.Upsert(ctx, 100, 200, "confirmed", "max_bot")
+	rec, err := r.Upsert(ctx, 100, 200, "confirmed", "max")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if rec.Status != "confirmed" || rec.MotconsuID != 100 {
+	if rec.Status != "confirmed" || rec.PlanningID != 100 {
 		t.Fatalf("first upsert: %+v", rec)
 	}
 
-	rec2, err := r.Upsert(ctx, 100, 200, "declined", "max_bot")
+	rec2, err := r.Upsert(ctx, 100, 200, "declined", "max")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/confirmations/repo_test.go
+++ b/internal/confirmations/repo_test.go
@@ -1,0 +1,48 @@
+package confirmations
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/store"
+	_ "modernc.org/sqlite"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:confirmations_test?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Migrate(context.Background(), db); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestRepo_UpsertLastWriteWins(t *testing.T) {
+	db := openTestDB(t)
+	r := NewRepo(db)
+	ctx := context.Background()
+
+	rec, err := r.Upsert(ctx, 100, 200, "confirmed", "max_bot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Status != "confirmed" || rec.MotconsuID != 100 {
+		t.Fatalf("first upsert: %+v", rec)
+	}
+
+	rec2, err := r.Upsert(ctx, 100, 200, "declined", "max_bot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec2.Status != "declined" {
+		t.Fatalf("expected declined, got %q", rec2.Status)
+	}
+	if !rec2.UpdatedAt.Equal(rec.UpdatedAt) && !rec2.UpdatedAt.After(rec.UpdatedAt) {
+		t.Fatalf("updated_at should advance: %v vs %v", rec.UpdatedAt, rec2.UpdatedAt)
+	}
+}

--- a/internal/confirmations/status.go
+++ b/internal/confirmations/status.go
@@ -1,0 +1,19 @@
+package confirmations
+
+import "strings"
+
+// Allowed confirmation statuses from MAX reminder buttons (PR #3b-bot).
+var allowedStatuses = map[string]struct{}{
+	"confirmed":  {},
+	"declined":   {},
+	"reschedule": {},
+}
+
+func ValidStatus(status string) bool {
+	_, ok := allowedStatuses[strings.ToLower(strings.TrimSpace(status))]
+	return ok
+}
+
+func NormalizeStatus(status string) string {
+	return strings.ToLower(strings.TrimSpace(status))
+}

--- a/internal/confirmations/status_test.go
+++ b/internal/confirmations/status_test.go
@@ -1,0 +1,22 @@
+package confirmations
+
+import "testing"
+
+func TestValidStatus(t *testing.T) {
+	for _, s := range []string{"confirmed", "declined", "reschedule", "CONFIRMED"} {
+		if !ValidStatus(s) {
+			t.Fatalf("expected valid: %q", s)
+		}
+	}
+	for _, s := range []string{"", "yes", "cancelled", "pending"} {
+		if ValidStatus(s) {
+			t.Fatalf("expected invalid: %q", s)
+		}
+	}
+}
+
+func TestNormalizeStatus(t *testing.T) {
+	if got := NormalizeStatus(" Reschedule "); got != "reschedule" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/handler/confirmations.go
+++ b/internal/handler/confirmations.go
@@ -1,0 +1,89 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/confirmations"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/response"
+)
+
+type ConfirmationsService interface {
+	UpsertConfirmation(ctx context.Context, motconsuID, patientID int64, status, source string) (confirmations.Record, error)
+}
+
+type ConfirmationsHandler struct {
+	Svc    ConfirmationsService
+	Logger *slog.Logger
+	Now    func() time.Time
+}
+
+type confirmationRequest struct {
+	MotconsuID int64  `json:"motconsu_id"`
+	PatientID  int64  `json:"patient_id"`
+	Status     string `json:"status"`
+	Source     string `json:"source,omitempty"`
+}
+
+type confirmationDTO struct {
+	MotconsuID int64  `json:"motconsu_id"`
+	PatientID  int64  `json:"patient_id"`
+	Status     string `json:"status"`
+	Source     string `json:"source"`
+	UpdatedAt  string `json:"updated_at"`
+}
+
+func (h ConfirmationsHandler) Upsert(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		response.Error(w, http.StatusBadRequest, "VALIDATION", "Некорректное тело запроса")
+		return
+	}
+
+	var req confirmationRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		response.Error(w, http.StatusBadRequest, "VALIDATION", "Некорректный JSON")
+		return
+	}
+	if req.MotconsuID <= 0 || req.PatientID <= 0 {
+		response.Error(w, http.StatusBadRequest, "VALIDATION", "motconsu_id и patient_id обязательны")
+		return
+	}
+	if !confirmations.ValidStatus(req.Status) {
+		response.Error(w, http.StatusBadRequest, "VALIDATION", "status: допустимые значения confirmed, declined, reschedule")
+		return
+	}
+
+	source := strings.TrimSpace(req.Source)
+	if source == "" {
+		source = "max_bot"
+	}
+
+	rec, err := h.Svc.UpsertConfirmation(r.Context(), req.MotconsuID, req.PatientID, req.Status, source)
+	if err != nil {
+		switch {
+		case errors.Is(err, confirmations.ErrAppointmentNotFound):
+			response.Error(w, http.StatusNotFound, "APPOINTMENT_NOT_FOUND", "Запись на приём не найдена")
+		case errors.Is(err, confirmations.ErrPatientMismatch):
+			response.Error(w, http.StatusForbidden, "PATIENT_MISMATCH", "Пациент не владеет этой записью")
+		default:
+			h.Logger.Error("confirmation upsert failed", "err", err)
+			response.Error(w, http.StatusInternalServerError, "INTERNAL", "Внутренняя ошибка")
+		}
+		return
+	}
+
+	response.OK(w, confirmationDTO{
+		MotconsuID: rec.MotconsuID,
+		PatientID:  rec.PatientID,
+		Status:     rec.Status,
+		Source:     rec.Source,
+		UpdatedAt:  rec.UpdatedAt.Format("2006-01-02T15:04:05"),
+	})
+}

--- a/internal/handler/confirmations.go
+++ b/internal/handler/confirmations.go
@@ -8,31 +8,29 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/medkvadrat/medkvadrat-patient-api/internal/confirmations"
 	"github.com/medkvadrat/medkvadrat-patient-api/internal/response"
 )
 
 type ConfirmationsService interface {
-	UpsertConfirmation(ctx context.Context, motconsuID, patientID int64, status, source string) (confirmations.Record, error)
+	UpsertConfirmation(ctx context.Context, planningID, patientID int64, status, source string) (confirmations.Record, error)
 }
 
 type ConfirmationsHandler struct {
 	Svc    ConfirmationsService
 	Logger *slog.Logger
-	Now    func() time.Time
 }
 
 type confirmationRequest struct {
-	MotconsuID int64  `json:"motconsu_id"`
+	PlanningID int64  `json:"planning_id"`
 	PatientID  int64  `json:"patient_id"`
 	Status     string `json:"status"`
 	Source     string `json:"source,omitempty"`
 }
 
 type confirmationDTO struct {
-	MotconsuID int64  `json:"motconsu_id"`
+	PlanningID int64  `json:"planning_id"`
 	PatientID  int64  `json:"patient_id"`
 	Status     string `json:"status"`
 	Source     string `json:"source"`
@@ -51,8 +49,8 @@ func (h ConfirmationsHandler) Upsert(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusBadRequest, "VALIDATION", "Некорректный JSON")
 		return
 	}
-	if req.MotconsuID <= 0 || req.PatientID <= 0 {
-		response.Error(w, http.StatusBadRequest, "VALIDATION", "motconsu_id и patient_id обязательны")
+	if req.PlanningID <= 0 || req.PatientID <= 0 {
+		response.Error(w, http.StatusBadRequest, "VALIDATION", "planning_id и patient_id обязательны")
 		return
 	}
 	if !confirmations.ValidStatus(req.Status) {
@@ -62,10 +60,10 @@ func (h ConfirmationsHandler) Upsert(w http.ResponseWriter, r *http.Request) {
 
 	source := strings.TrimSpace(req.Source)
 	if source == "" {
-		source = "max_bot"
+		source = "max"
 	}
 
-	rec, err := h.Svc.UpsertConfirmation(r.Context(), req.MotconsuID, req.PatientID, req.Status, source)
+	rec, err := h.Svc.UpsertConfirmation(r.Context(), req.PlanningID, req.PatientID, req.Status, source)
 	if err != nil {
 		switch {
 		case errors.Is(err, confirmations.ErrAppointmentNotFound):
@@ -80,7 +78,7 @@ func (h ConfirmationsHandler) Upsert(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.OK(w, confirmationDTO{
-		MotconsuID: rec.MotconsuID,
+		PlanningID: rec.PlanningID,
 		PatientID:  rec.PatientID,
 		Status:     rec.Status,
 		Source:     rec.Source,

--- a/internal/handler/golden_confirmations_test.go
+++ b/internal/handler/golden_confirmations_test.go
@@ -1,0 +1,100 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/confirmations"
+)
+
+type fakeConfirmationsSvc struct {
+	lastMotconsuID int64
+	lastPatientID  int64
+	lastStatus     string
+	err            error
+}
+
+func (f *fakeConfirmationsSvc) UpsertConfirmation(ctx context.Context, motconsuID, patientID int64, status, source string) (confirmations.Record, error) {
+	f.lastMotconsuID = motconsuID
+	f.lastPatientID = patientID
+	f.lastStatus = status
+	if f.err != nil {
+		return confirmations.Record{}, f.err
+	}
+	return confirmations.Record{
+		MotconsuID: motconsuID,
+		PatientID:  patientID,
+		Status:     status,
+		Source:     source,
+		UpdatedAt:  time.Date(2026, 6, 23, 15, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func TestGolden_Confirmations_Upsert_OK(t *testing.T) {
+	svc := &fakeConfirmationsSvc{}
+	h := ConfirmationsHandler{Svc: svc}
+	body := `{"motconsu_id":12345,"patient_id":6789,"status":"confirmed"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/internal/confirmations", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	h.Upsert(w, r)
+	assertGolden(t, "confirmations_upsert_ok", w.Body.Bytes())
+	if svc.lastStatus != "confirmed" {
+		t.Fatalf("status=%q", svc.lastStatus)
+	}
+}
+
+func TestGolden_Confirmations_InvalidStatus(t *testing.T) {
+	h := ConfirmationsHandler{Svc: &fakeConfirmationsSvc{}}
+	body := `{"motconsu_id":1,"patient_id":2,"status":"maybe"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/internal/confirmations", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	h.Upsert(w, r)
+	assertGolden(t, "confirmations_invalid_status", w.Body.Bytes())
+}
+
+func TestGolden_Confirmations_NotFound(t *testing.T) {
+	h := ConfirmationsHandler{Svc: &fakeConfirmationsSvc{err: confirmations.ErrAppointmentNotFound}}
+	body := `{"motconsu_id":1,"patient_id":2,"status":"confirmed"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/internal/confirmations", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	h.Upsert(w, r)
+	assertGolden(t, "confirmations_not_found", w.Body.Bytes())
+}
+
+func TestGolden_Confirmations_PatientMismatch(t *testing.T) {
+	h := ConfirmationsHandler{Svc: &fakeConfirmationsSvc{err: confirmations.ErrPatientMismatch}}
+	body := `{"motconsu_id":1,"patient_id":2,"status":"declined"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/internal/confirmations", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	h.Upsert(w, r)
+	assertGolden(t, "confirmations_patient_mismatch", w.Body.Bytes())
+}
+
+func Test__GenerateConfirmationsGolden(t *testing.T) {
+	if os.Getenv("UPDATE_GOLDEN") != "1" {
+		t.Skip("set UPDATE_GOLDEN=1 to (re)generate golden files")
+	}
+	svc := &fakeConfirmationsSvc{}
+	cases := []struct {
+		name string
+		body string
+		svc  ConfirmationsService
+	}{
+		{"confirmations_upsert_ok", `{"motconsu_id":12345,"patient_id":6789,"status":"confirmed"}`, svc},
+		{"confirmations_invalid_status", `{"motconsu_id":1,"patient_id":2,"status":"maybe"}`, &fakeConfirmationsSvc{}},
+		{"confirmations_not_found", `{"motconsu_id":1,"patient_id":2,"status":"confirmed"}`, &fakeConfirmationsSvc{err: confirmations.ErrAppointmentNotFound}},
+		{"confirmations_patient_mismatch", `{"motconsu_id":1,"patient_id":2,"status":"declined"}`, &fakeConfirmationsSvc{err: confirmations.ErrPatientMismatch}},
+	}
+	for _, c := range cases {
+		h := ConfirmationsHandler{Svc: c.svc}
+		r := httptest.NewRequest(http.MethodPost, "/api/internal/confirmations", bytes.NewBufferString(c.body))
+		w := httptest.NewRecorder()
+		h.Upsert(w, r)
+		writeGolden(t, c.name, w.Body.Bytes())
+	}
+}

--- a/internal/handler/golden_confirmations_test.go
+++ b/internal/handler/golden_confirmations_test.go
@@ -13,21 +13,21 @@ import (
 )
 
 type fakeConfirmationsSvc struct {
-	lastMotconsuID int64
+	lastPlanningID int64
 	lastPatientID  int64
 	lastStatus     string
 	err            error
 }
 
-func (f *fakeConfirmationsSvc) UpsertConfirmation(ctx context.Context, motconsuID, patientID int64, status, source string) (confirmations.Record, error) {
-	f.lastMotconsuID = motconsuID
+func (f *fakeConfirmationsSvc) UpsertConfirmation(ctx context.Context, planningID, patientID int64, status, source string) (confirmations.Record, error) {
+	f.lastPlanningID = planningID
 	f.lastPatientID = patientID
 	f.lastStatus = status
 	if f.err != nil {
 		return confirmations.Record{}, f.err
 	}
 	return confirmations.Record{
-		MotconsuID: motconsuID,
+		PlanningID: planningID,
 		PatientID:  patientID,
 		Status:     status,
 		Source:     source,
@@ -38,19 +38,19 @@ func (f *fakeConfirmationsSvc) UpsertConfirmation(ctx context.Context, motconsuI
 func TestGolden_Confirmations_Upsert_OK(t *testing.T) {
 	svc := &fakeConfirmationsSvc{}
 	h := ConfirmationsHandler{Svc: svc}
-	body := `{"motconsu_id":12345,"patient_id":6789,"status":"confirmed"}`
+	body := `{"planning_id":11737097,"patient_id":1587578,"status":"confirmed","source":"max"}`
 	r := httptest.NewRequest(http.MethodPost, "/api/internal/confirmations", bytes.NewBufferString(body))
 	w := httptest.NewRecorder()
 	h.Upsert(w, r)
 	assertGolden(t, "confirmations_upsert_ok", w.Body.Bytes())
-	if svc.lastStatus != "confirmed" {
-		t.Fatalf("status=%q", svc.lastStatus)
+	if svc.lastPlanningID != 11737097 {
+		t.Fatalf("planning_id=%d", svc.lastPlanningID)
 	}
 }
 
 func TestGolden_Confirmations_InvalidStatus(t *testing.T) {
 	h := ConfirmationsHandler{Svc: &fakeConfirmationsSvc{}}
-	body := `{"motconsu_id":1,"patient_id":2,"status":"maybe"}`
+	body := `{"planning_id":1,"patient_id":2,"status":"maybe"}`
 	r := httptest.NewRequest(http.MethodPost, "/api/internal/confirmations", bytes.NewBufferString(body))
 	w := httptest.NewRecorder()
 	h.Upsert(w, r)
@@ -59,7 +59,7 @@ func TestGolden_Confirmations_InvalidStatus(t *testing.T) {
 
 func TestGolden_Confirmations_NotFound(t *testing.T) {
 	h := ConfirmationsHandler{Svc: &fakeConfirmationsSvc{err: confirmations.ErrAppointmentNotFound}}
-	body := `{"motconsu_id":1,"patient_id":2,"status":"confirmed"}`
+	body := `{"planning_id":1,"patient_id":2,"status":"confirmed"}`
 	r := httptest.NewRequest(http.MethodPost, "/api/internal/confirmations", bytes.NewBufferString(body))
 	w := httptest.NewRecorder()
 	h.Upsert(w, r)
@@ -68,7 +68,7 @@ func TestGolden_Confirmations_NotFound(t *testing.T) {
 
 func TestGolden_Confirmations_PatientMismatch(t *testing.T) {
 	h := ConfirmationsHandler{Svc: &fakeConfirmationsSvc{err: confirmations.ErrPatientMismatch}}
-	body := `{"motconsu_id":1,"patient_id":2,"status":"declined"}`
+	body := `{"planning_id":1,"patient_id":2,"status":"declined"}`
 	r := httptest.NewRequest(http.MethodPost, "/api/internal/confirmations", bytes.NewBufferString(body))
 	w := httptest.NewRecorder()
 	h.Upsert(w, r)
@@ -85,10 +85,10 @@ func Test__GenerateConfirmationsGolden(t *testing.T) {
 		body string
 		svc  ConfirmationsService
 	}{
-		{"confirmations_upsert_ok", `{"motconsu_id":12345,"patient_id":6789,"status":"confirmed"}`, svc},
-		{"confirmations_invalid_status", `{"motconsu_id":1,"patient_id":2,"status":"maybe"}`, &fakeConfirmationsSvc{}},
-		{"confirmations_not_found", `{"motconsu_id":1,"patient_id":2,"status":"confirmed"}`, &fakeConfirmationsSvc{err: confirmations.ErrAppointmentNotFound}},
-		{"confirmations_patient_mismatch", `{"motconsu_id":1,"patient_id":2,"status":"declined"}`, &fakeConfirmationsSvc{err: confirmations.ErrPatientMismatch}},
+		{"confirmations_upsert_ok", `{"planning_id":11737097,"patient_id":1587578,"status":"confirmed","source":"max"}`, svc},
+		{"confirmations_invalid_status", `{"planning_id":1,"patient_id":2,"status":"maybe"}`, &fakeConfirmationsSvc{}},
+		{"confirmations_not_found", `{"planning_id":1,"patient_id":2,"status":"confirmed"}`, &fakeConfirmationsSvc{err: confirmations.ErrAppointmentNotFound}},
+		{"confirmations_patient_mismatch", `{"planning_id":1,"patient_id":2,"status":"declined"}`, &fakeConfirmationsSvc{err: confirmations.ErrPatientMismatch}},
 	}
 	for _, c := range cases {
 		h := ConfirmationsHandler{Svc: c.svc}

--- a/internal/handler/testdata/golden/confirmations_invalid_status.json
+++ b/internal/handler/testdata/golden/confirmations_invalid_status.json
@@ -1,0 +1,1 @@
+{"success":false,"error":"status: допустимые значения confirmed, declined, reschedule","error_details":{"code":"VALIDATION","message":"status: допустимые значения confirmed, declined, reschedule"}}

--- a/internal/handler/testdata/golden/confirmations_not_found.json
+++ b/internal/handler/testdata/golden/confirmations_not_found.json
@@ -1,0 +1,1 @@
+{"success":false,"error":"Запись на приём не найдена","error_details":{"code":"APPOINTMENT_NOT_FOUND","message":"Запись на приём не найдена"}}

--- a/internal/handler/testdata/golden/confirmations_patient_mismatch.json
+++ b/internal/handler/testdata/golden/confirmations_patient_mismatch.json
@@ -1,0 +1,1 @@
+{"success":false,"error":"Пациент не владеет этой записью","error_details":{"code":"PATIENT_MISMATCH","message":"Пациент не владеет этой записью"}}

--- a/internal/handler/testdata/golden/confirmations_upsert_ok.json
+++ b/internal/handler/testdata/golden/confirmations_upsert_ok.json
@@ -1,1 +1,1 @@
-{"success":true,"data":{"motconsu_id":12345,"patient_id":6789,"status":"confirmed","source":"max_bot","updated_at":"2026-06-23T15:00:00"}}
+{"success":true,"data":{"planning_id":11737097,"patient_id":1587578,"status":"confirmed","source":"max","updated_at":"2026-06-23T15:00:00"}}

--- a/internal/handler/testdata/golden/confirmations_upsert_ok.json
+++ b/internal/handler/testdata/golden/confirmations_upsert_ok.json
@@ -1,0 +1,1 @@
+{"success":true,"data":{"motconsu_id":12345,"patient_id":6789,"status":"confirmed","source":"max_bot","updated_at":"2026-06-23T15:00:00"}}

--- a/internal/repo/motconsu_owner.go
+++ b/internal/repo/motconsu_owner.go
@@ -1,0 +1,25 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/confirmations"
+)
+
+// MotconsuPatientID returns PATIENTS_ID for an appointment (read-only Medialog check).
+func MotconsuPatientID(ctx context.Context, db *sql.DB, motconsuID int64) (int64, error) {
+	var patientID int64
+	err := db.QueryRowContext(ctx, `
+SELECT PATIENTS_ID FROM MOTCONSU WHERE MOTCONSU_ID = @id`,
+		sql.Named("id", motconsuID),
+	).Scan(&patientID)
+	if err == sql.ErrNoRows {
+		return 0, confirmations.ErrAppointmentNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("motconsu patient lookup: %w", err)
+	}
+	return patientID, nil
+}

--- a/internal/repo/planning_owner.go
+++ b/internal/repo/planning_owner.go
@@ -8,18 +8,18 @@ import (
 	"github.com/medkvadrat/medkvadrat-patient-api/internal/confirmations"
 )
 
-// MotconsuPatientID returns PATIENTS_ID for an appointment (read-only Medialog check).
-func MotconsuPatientID(ctx context.Context, db *sql.DB, motconsuID int64) (int64, error) {
+// PlanningPatientID returns PATIENTS_ID for a scheduled appointment (read-only).
+func PlanningPatientID(ctx context.Context, db *sql.DB, planningID int64) (int64, error) {
 	var patientID int64
 	err := db.QueryRowContext(ctx, `
-SELECT PATIENTS_ID FROM MOTCONSU WHERE MOTCONSU_ID = @id`,
-		sql.Named("id", motconsuID),
+SELECT PATIENTS_ID FROM PLANNING WHERE PLANNING_ID = @id`,
+		sql.Named("id", planningID),
 	).Scan(&patientID)
 	if err == sql.ErrNoRows {
 		return 0, confirmations.ErrAppointmentNotFound
 	}
 	if err != nil {
-		return 0, fmt.Errorf("motconsu patient lookup: %w", err)
+		return 0, fmt.Errorf("planning patient lookup: %w", err)
 	}
 	return patientID, nil
 }

--- a/internal/service/confirmations.go
+++ b/internal/service/confirmations.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"context"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/confirmations"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/repo"
+)
+
+func (s *Services) UpsertConfirmation(ctx context.Context, motconsuID, patientID int64, status, source string) (confirmations.Record, error) {
+	ownerID, err := repo.MotconsuPatientID(ctx, s.MSSQL, motconsuID)
+	if err != nil {
+		return confirmations.Record{}, err
+	}
+	if ownerID != patientID {
+		return confirmations.Record{}, confirmations.ErrPatientMismatch
+	}
+	return confirmations.NewRepo(s.SQLite).Upsert(ctx, motconsuID, patientID, status, source)
+}

--- a/internal/service/confirmations.go
+++ b/internal/service/confirmations.go
@@ -7,13 +7,13 @@ import (
 	"github.com/medkvadrat/medkvadrat-patient-api/internal/repo"
 )
 
-func (s *Services) UpsertConfirmation(ctx context.Context, motconsuID, patientID int64, status, source string) (confirmations.Record, error) {
-	ownerID, err := repo.MotconsuPatientID(ctx, s.MSSQL, motconsuID)
+func (s *Services) UpsertConfirmation(ctx context.Context, planningID, patientID int64, status, source string) (confirmations.Record, error) {
+	ownerID, err := repo.PlanningPatientID(ctx, s.MSSQL, planningID)
 	if err != nil {
 		return confirmations.Record{}, err
 	}
 	if ownerID != patientID {
 		return confirmations.Record{}, confirmations.ErrPatientMismatch
 	}
-	return confirmations.NewRepo(s.SQLite).Upsert(ctx, motconsuID, patientID, status, source)
+	return confirmations.NewRepo(s.SQLite).Upsert(ctx, planningID, patientID, status, source)
 }

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -44,6 +44,14 @@ CREATE TABLE IF NOT EXISTS rate_limits (
   PRIMARY KEY(scope, rl_key, window_sec, limit_count)
 );`,
 		`CREATE INDEX IF NOT EXISTS idx_rate_expires ON rate_limits(expires_at);`,
+		`
+CREATE TABLE IF NOT EXISTS appointment_confirmations (
+  motconsu_id INTEGER PRIMARY KEY,
+  patient_id  INTEGER NOT NULL,
+  status      TEXT NOT NULL,
+  source      TEXT NOT NULL DEFAULT 'max_bot',
+  updated_at  DATETIME NOT NULL
+);`,
 	}
 
 	for i, s := range stmts {

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -46,10 +46,10 @@ CREATE TABLE IF NOT EXISTS rate_limits (
 		`CREATE INDEX IF NOT EXISTS idx_rate_expires ON rate_limits(expires_at);`,
 		`
 CREATE TABLE IF NOT EXISTS appointment_confirmations (
-  motconsu_id INTEGER PRIMARY KEY,
-  patient_id  INTEGER NOT NULL,
+  planning_id INTEGER PRIMARY KEY,
   status      TEXT NOT NULL,
-  source      TEXT NOT NULL DEFAULT 'max_bot',
+  source      TEXT NOT NULL DEFAULT 'max',
+  patient_id  INTEGER,
   updated_at  DATETIME NOT NULL
 );`,
 	}


### PR DESCRIPTION
## Summary
- POST /api/internal/confirmations — overlay ответа пациента на напоминание
- Авторизация: **API_TOKEN** (тот же Bearer, что /api/reminders/due и остальные S2S)
- status ∈ confirmed | declined | reschedule
- Владелец: SELECT PATIENTS_ID FROM MOTCONSU → 403/404
- SQLite appointment_confirmations, upsert LWW

## Test plan
- [x] go test ./...
- [x] маршрут под RequireBearer (не отдельный INTERNAL_API_TOKEN)
- [ ] live: бот POST после кнопки (PR #3b-bot)

В Медиалог не пишем.