### PR TITLE
chore: remove PII from logs, document rule in MEDIALOG_RULES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /api-gateway
 *.db
 *.db-*
+tools/planningdiag/

--- a/docs/MEDIALOG_RULES.md
+++ b/docs/MEDIALOG_RULES.md
@@ -39,3 +39,25 @@ Golden/unit тесты через моки **не ловят**:
 
 Каждый write‑эндпоинт в Medialog должен иметь integration‑тест под build‑tag `integration` и прогоняться на dev MSSQL через `./scripts/integration-test.sh`.
 
+## Персональные данные в логах
+
+Правило того же уровня, что read-only по Medialog. Применяется ко **всем** PR и окружениям (prod, стенд, локально).
+
+### Обязательно
+
+- В логи (`slog`, stdout, middleware) — **только идентификаторы**: `patient_id`, `planning_id`, `motconsu_id`, `doctor_id`, `branch_id`, `request_id`, `status`, `latency_ms`, `err`.
+- ФИО (`NOM`/`PRENOM`, `patient_name`, `doctor_name`, `full_name`), телефон, email, адрес, дата рождения — **никогда** в логах.
+- ПДн допустимы **только в теле HTTP-ответа** авторизованному клиенту по контракту эндпоинта (staff/S2S, JWT пациента).
+- Handler-ошибки логировать как `err` + id из контекста запроса, **без** сериализации DTO/`data`.
+- Read-path SQL не джойнить `PATIENTS`/`MEDECINS` ради имён, если имена нужны только для логов или отладки — убрать данные из выборки, а не из формата лога.
+- **Не запускать** `patient-api` и diag-утилиты против боевого Medialog (`192.168.2.229`) из облачных агентов (Cursor Cloud и т.п.) — риск утечки ПДн в лог агента.
+
+### Исключения
+
+- Маскированные значения, если без них нельзя отладить (например `masked_email` в OTP audit).
+- `AUTH_MODE=dev`: OTP-код в лог допустим только на изолированном dev-инстансе.
+
+### Локальные diag-утилиты
+
+`tools/planningdiag/` — read-only (`SELECT` only), не в git (`.gitignore`). Вывод в stdout может содержать ПДн; не коммитить, не гонять на проде.
+

--- a/internal/poll/poll.go
+++ b/internal/poll/poll.go
@@ -93,8 +93,8 @@ func (p *MotconsuPoller) tick(ctx context.Context) {
 			p.logger.Info(
 				"motconsu changed",
 				"motconsu_id", r.MotconsuID,
-				"patient", r.PatientNom+" "+r.PatientPrenom,
-				"doctor", r.DoctorNom+" "+r.DoctorPrenom,
+				"patient_id", r.PatientID,
+				"doctor_id", r.DoctorID,
 				"date", r.DateConsult.Format("02.01.2006 15:04"),
 			)
 			p.seenTalons[r.MotconsuID] = struct{}{}

--- a/internal/repo/motconsu.go
+++ b/internal/repo/motconsu.go
@@ -53,26 +53,18 @@ func (r *MotconsuRepo) ChangesSince(ctx context.Context, since time.Time) ([]Sch
 }
 
 type PollRow struct {
-	MotconsuID    int
-	PatientID     int
-	DoctorID      int
-	DateConsult   time.Time
-	ModifyDate    time.Time
-	PatientNom    string
-	PatientPrenom string
-	DoctorNom     string
-	DoctorPrenom  string
+	MotconsuID  int
+	PatientID   int
+	DoctorID    int
+	DateConsult time.Time
+	ModifyDate  time.Time
 }
 
 func (r *MotconsuRepo) PollAfter(ctx context.Context, last time.Time) ([]PollRow, error) {
 	query := `
 		SELECT m.MOTCONSU_ID, m.PATIENTS_ID, m.MEDECINS_ID,
-			m.DATE_CONSULTATION, m.KRN_MODIFY_DATE,
-			ISNULL(p.NOM,'') AS PAT_NOM, ISNULL(p.PRENOM,'') AS PAT_PRENOM,
-			ISNULL(d.NOM,'') AS DOC_NOM, ISNULL(d.PRENOM,'') AS DOC_PRENOM
+			m.DATE_CONSULTATION, m.KRN_MODIFY_DATE
 		FROM MOTCONSU m
-		LEFT JOIN PATIENTS p ON p.PATIENTS_ID = m.PATIENTS_ID
-		LEFT JOIN MEDECINS d ON d.MEDECINS_ID = m.MEDECINS_ID
 		WHERE m.KRN_MODIFY_DATE > @lastDate
 		ORDER BY m.KRN_MODIFY_DATE ASC`
 
@@ -85,7 +77,7 @@ func (r *MotconsuRepo) PollAfter(ctx context.Context, last time.Time) ([]PollRow
 	var out []PollRow
 	for rows.Next() {
 		var pr PollRow
-		if err := rows.Scan(&pr.MotconsuID, &pr.PatientID, &pr.DoctorID, &pr.DateConsult, &pr.ModifyDate, &pr.PatientNom, &pr.PatientPrenom, &pr.DoctorNom, &pr.DoctorPrenom); err != nil {
+		if err := rows.Scan(&pr.MotconsuID, &pr.PatientID, &pr.DoctorID, &pr.DateConsult, &pr.ModifyDate); err != nil {
 			return nil, fmt.Errorf("scan poll: %w", err)
 		}
 		out = append(out, pr)

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -122,7 +122,6 @@ func (s *Services) OTPRequest(ctx context.Context, phoneRaw string, ipRaw string
 			if s.Config.Auth.Mode == "dev" {
 				s.Logger.Warn(
 					"otp request blocked: patient email missing",
-					"phone", phone,
 					"hint", "set PATIENTS.EMAIL on dev MSSQL or use AUTH_MODE=pilot with AUTH_PILOT_WHITELIST for happy-path testing",
 				)
 			}


### PR DESCRIPTION
## Summary
- Motconsu poller: log only `patient_id`/`doctor_id`; `PollAfter` no longer joins PATIENTS/MEDECINS for names (PII removed at source, not just from log format).
- OTP dev warn: remove raw phone from log line.
- Add forward-looking PDN logging rule to `docs/MEDIALOG_RULES.md` (ids only in logs; PDN only in authorized response bodies; no patient-api against 192.168.2.229 from cloud agents).
- `tools/planningdiag/` in `.gitignore` (read-only SELECT, local diag only).

## Caller check
`PollAfter` is only consumed by `internal/poll/poll.go`, which uses `motconsu_id`, `patient_id`, `doctor_id`, `date` — no name fields.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`

## Merge order
Merge this before PR #15 (dashboard schedule).