### PR TITLE
feat(api): serve dashboard page with staff session auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Copy to .env and fill in. Do not commit secrets.
+
+ENV=dev
+LOG_LEVEL=info
+API_PORT=:8080
+API_TOKEN=
+
+# Medialog MSSQL (DB_SERVER is Medialog host — do not change without confirmation)
+DB_SERVER=
+DB_PORT=1433
+DB_NAME=
+DB_USER=
+DB_PASSWORD=
+DB_ENCRYPT=disable
+DB_TRUST_SERVER_CERT=false
+
+GATEWAY_DB_PATH=./gateway.db
+
+AUTH_MODE=dev
+OTP_HMAC_SECRET=
+JWT_SECRET=
+
+# Staff dashboard (HTTP page + /dashboard/data). Password/secret required or /dashboard returns 503.
+# Stand host: http://192.168.2.104:<API_PORT>/dashboard
+DASHBOARD_PASSWORD=
+DASHBOARD_SECRET=
+DASHBOARD_SESSION_TTL=12h
+DASHBOARD_COOKIE_SECURE=false
+DASHBOARD_ALLOWED_CIDRS=192.168.0.0/16,127.0.0.1/32

--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ The script must be executable (`chmod +x scripts/dev-smoke.sh`). It exercises OT
 
 `GET /api/me/profile` exposes `birth_date` (`YYYY-MM-DD`) from Medialog `PATIENTS.NE_LE` when set, otherwise `birth_year` from `GOD_ROGDENIQ`. Clients should show one or the other, not both.
 
+## Staff dashboard
+
+Internal schedule board for three branches (staff session, not `API_TOKEN`):
+
+- Page: `GET /dashboard` (login at `/dashboard/login`)
+- Data: `GET /dashboard/data?date=YYYY-MM-DD` (same JSON as `GET /api/dashboard/schedule`)
+
+Env: `DASHBOARD_PASSWORD`, `DASHBOARD_SECRET` (`openssl rand -hex 32`), optional `DASHBOARD_SESSION_TTL` (default `12h`), `DASHBOARD_COOKIE_SECURE` (default `false` for LAN HTTP), `DASHBOARD_ALLOWED_CIDRS` (default `192.168.0.0/16,127.0.0.1/32`).
+
+Stand (LAN): `http://192.168.2.104:<API_PORT>/dashboard`. `API_TOKEN` must never appear in the page/JS — the browser uses the `mk_staff` cookie only.
+
+S2S clients keep using `GET /api/dashboard/schedule` with `Authorization: Bearer <API_TOKEN>`.
+
 ## Integration tests (MSSQL)
 
 Integration tests verify behavior against a real dev MSSQL instance. They cover write paths (book/cancel/restore) that mocks can't simulate — clinic-side triggers and stored procedures.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -8,7 +8,9 @@ import (
 	"github.com/medkvadrat/medkvadrat-patient-api/internal/config"
 	"github.com/medkvadrat/medkvadrat-patient-api/internal/handler"
 	"github.com/medkvadrat/medkvadrat-patient-api/internal/middleware"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/ratelimit"
 	"github.com/medkvadrat/medkvadrat-patient-api/internal/service"
+	"github.com/medkvadrat/medkvadrat-patient-api/web"
 )
 
 func NewRouter(cfg config.Config, svc *service.Services, logger *slog.Logger) http.Handler {
@@ -24,6 +26,15 @@ func NewRouter(cfg config.Config, svc *service.Services, logger *slog.Logger) ht
 	confirmationsH := handler.ConfirmationsHandler{Svc: svc, Logger: logger}
 	remindersH := handler.RemindersHandler{Svc: svc, Logger: logger}
 	dashboardH := handler.DashboardHandler{Svc: svc, Logger: logger}
+	dashboardPageH := handler.DashboardPageHandler{
+		HTML:         web.DashboardHTML,
+		Password:     cfg.Dashboard.Password,
+		Secret:       []byte(cfg.Dashboard.Secret),
+		SessionTTL:   cfg.Dashboard.SessionTTL,
+		CookieSecure: cfg.Dashboard.CookieSecure,
+		RateLimit:    ratelimit.NewStore(svc.SQLite),
+		Logger:       logger,
+	}
 
 	// Public
 	mux.HandleFunc("GET /api/health", healthH.Health)
@@ -58,9 +69,31 @@ func NewRouter(cfg config.Config, svc *service.Services, logger *slog.Logger) ht
 	// Server-to-server (API_TOKEN), same as /api/reminders/due
 	mux.HandleFunc("POST /api/internal/confirmations", confirmationsH.Upsert)
 
+	// Staff dashboard (session cookie; not API_TOKEN)
+	mux.HandleFunc("GET /dashboard/login", dashboardPageH.LoginForm)
+	mux.HandleFunc("POST /dashboard/login", dashboardPageH.LoginPost)
+	mux.HandleFunc("POST /dashboard/logout", dashboardPageH.Logout)
+
+	staff := middleware.RequireStaff{Secret: []byte(cfg.Dashboard.Secret)}
+	mux.Handle("GET /dashboard", staff.Wrap(http.HandlerFunc(dashboardPageH.Page)))
+	mux.Handle("GET /dashboard/data", staff.Wrap(http.HandlerFunc(dashboardH.Schedule)))
+
+	cidrNets, err := middleware.ParseCIDRList(cfg.Dashboard.AllowedCIDRs)
+	if err != nil || len(cidrNets) == 0 {
+		if err != nil {
+			logger.Error("invalid DASHBOARD_ALLOWED_CIDRS, using defaults", "err", err)
+		}
+		cidrNets, _ = middleware.ParseCIDRList([]string{"192.168.0.0/16", "127.0.0.1/32"})
+	}
+	cidr := middleware.AllowCIDRs{Nets: cidrNets}
+
 	auth := middleware.Auth{Token: cfg.APIToken}
 	reqPatient := middleware.RequirePatient{JWTSecret: []byte(cfg.JWT.Secret)}
 	var base http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/dashboard") {
+			cidr.Wrap(mux).ServeHTTP(w, r)
+			return
+		}
 		if strings.HasPrefix(r.URL.Path, "/api/auth/") || r.URL.Path == "/api/health" {
 			mux.ServeHTTP(w, r)
 			return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,13 +20,22 @@ type Config struct {
 	// when patient cancellation is allowed.
 	CancelMinHoursBefore int
 
-	HTTP   HTTPConfig
-	MSSQL  MSSQLConfig
-	Auth   AuthConfig
-	OTP    OTPConfig
-	JWT    JWTConfig
-	SMTP   SMTPConfig
-	SQLite SQLiteConfig
+	HTTP      HTTPConfig
+	MSSQL     MSSQLConfig
+	Auth      AuthConfig
+	OTP       OTPConfig
+	JWT       JWTConfig
+	SMTP      SMTPConfig
+	SQLite    SQLiteConfig
+	Dashboard DashboardConfig
+}
+
+type DashboardConfig struct {
+	Password     string
+	Secret       string
+	SessionTTL   time.Duration
+	CookieSecure bool
+	AllowedCIDRs []string
 }
 
 type HTTPConfig struct {
@@ -133,6 +142,13 @@ func Load() (Config, error) {
 			FromName:  strings.TrimSpace(getEnv("SMTP_FROM_NAME", "МедКвадрат")),
 			FromEmail: strings.TrimSpace(getEnv("SMTP_FROM_EMAIL", "")),
 			TLSMode:   strings.ToLower(strings.TrimSpace(getEnv("SMTP_TLS", "starttls"))),
+		},
+		Dashboard: DashboardConfig{
+			Password:     os.Getenv("DASHBOARD_PASSWORD"),
+			Secret:       strings.TrimSpace(os.Getenv("DASHBOARD_SECRET")),
+			SessionTTL:   mustDuration(getEnv("DASHBOARD_SESSION_TTL", "12h")),
+			CookieSecure: mustBool(getEnv("DASHBOARD_COOKIE_SECURE", "false")),
+			AllowedCIDRs: splitCSV(getEnv("DASHBOARD_ALLOWED_CIDRS", "192.168.0.0/16,127.0.0.1/32")),
 		},
 	}
 

--- a/internal/handler/dashboard_page.go
+++ b/internal/handler/dashboard_page.go
@@ -1,0 +1,145 @@
+package handler
+
+import (
+	"html"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/ratelimit"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/response"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/staffsession"
+)
+
+const (
+	dashboardLoginRateScope  = "dashboard_login"
+	dashboardLoginRateLimit  = 10
+	dashboardLoginRateWindow = 15 * time.Minute
+)
+
+// DashboardPageHandler serves the staff dashboard HTML and login/logout.
+type DashboardPageHandler struct {
+	HTML         []byte
+	Password     string
+	Secret       []byte
+	SessionTTL   time.Duration
+	CookieSecure bool
+	RateLimit    *ratelimit.Store
+	Logger       *slog.Logger
+	Now          func() time.Time
+}
+
+func (h DashboardPageHandler) now() time.Time {
+	if h.Now != nil {
+		return h.Now()
+	}
+	return time.Now()
+}
+
+func (h DashboardPageHandler) configured() bool {
+	return strings.TrimSpace(h.Password) != "" && len(h.Secret) > 0
+}
+
+func (h DashboardPageHandler) Page(w http.ResponseWriter, r *http.Request) {
+	if !h.configured() {
+		http.Error(w, "Dashboard not configured", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(h.HTML)
+}
+
+func (h DashboardPageHandler) LoginForm(w http.ResponseWriter, r *http.Request) {
+	h.writeLogin(w, "")
+}
+
+func (h DashboardPageHandler) LoginPost(w http.ResponseWriter, r *http.Request) {
+	if !h.configured() {
+		http.Error(w, "Dashboard not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	ip := staffsession.ClientIP(r.RemoteAddr)
+	if h.RateLimit != nil {
+		ok, err := h.RateLimit.Allow(r.Context(), dashboardLoginRateScope, ip, dashboardLoginRateWindow, dashboardLoginRateLimit, h.now())
+		if err != nil {
+			h.Logger.Error("dashboard login rate limit failed", "err", err, "ip", ip)
+		} else if !ok {
+			response.Error(w, http.StatusTooManyRequests, "RATE_LIMITED", "Слишком много попыток, попробуйте позже")
+			return
+		}
+	}
+
+	if err := r.ParseForm(); err != nil {
+		h.writeLogin(w, "Неверный пароль")
+		return
+	}
+	password := r.FormValue("password")
+	if !staffsession.PasswordMatch(h.Password, password) {
+		h.Logger.Info("dashboard login failed", "ip", ip)
+		h.writeLogin(w, "Неверный пароль")
+		return
+	}
+
+	ttl := h.SessionTTL
+	if ttl <= 0 {
+		ttl = 12 * time.Hour
+	}
+	exp := h.now().Add(ttl)
+	http.SetCookie(w, &http.Cookie{
+		Name:     staffsession.CookieName,
+		Value:    staffsession.Sign(h.Secret, exp),
+		Path:     "/dashboard",
+		Expires:  exp,
+		MaxAge:   int(ttl.Seconds()),
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   h.CookieSecure,
+	})
+	http.Redirect(w, r, "/dashboard", http.StatusFound)
+}
+
+func (h DashboardPageHandler) Logout(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     staffsession.CookieName,
+		Value:    "",
+		Path:     "/dashboard",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   h.CookieSecure,
+	})
+	http.Redirect(w, r, "/dashboard/login", http.StatusFound)
+}
+
+func (h DashboardPageHandler) writeLogin(w http.ResponseWriter, errMsg string) {
+	if !h.configured() {
+		http.Error(w, "Dashboard not configured", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	var b strings.Builder
+	b.WriteString(`<!DOCTYPE html><html lang="ru"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">`)
+	b.WriteString(`<title>Вход — дашборд МедКвадрат</title>`)
+	b.WriteString(`<style>body{font-family:system-ui,sans-serif;background:#EEF1EE;color:#0F1E1C;display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}`)
+	b.WriteString(`form{background:#fff;padding:28px 32px;border-radius:10px;border:1px solid #D5DBD7;min-width:280px}`)
+	b.WriteString(`h1{font-size:18px;margin:0 0 16px}label{display:block;font-size:13px;margin-bottom:6px}`)
+	b.WriteString(`input{width:100%;box-sizing:border-box;padding:8px 10px;font-size:15px;border:1px solid #D5DBD7;border-radius:6px}`)
+	b.WriteString(`button{margin-top:14px;width:100%;padding:10px;background:#0E4F45;color:#fff;border:0;border-radius:6px;font-size:14px;cursor:pointer}`)
+	b.WriteString(`.err{color:#B3261E;font-size:13px;margin:0 0 12px}</style></head><body>`)
+	b.WriteString(`<form method="post" action="/dashboard/login"><h1>Дашборд расписания</h1>`)
+	if errMsg != "" {
+		b.WriteString(`<p class="err">`)
+		b.WriteString(html.EscapeString(errMsg))
+		b.WriteString(`</p>`)
+	}
+	b.WriteString(`<label for="password">Пароль</label>`)
+	b.WriteString(`<input id="password" name="password" type="password" autocomplete="current-password" required autofocus>`)
+	b.WriteString(`<button type="submit">Войти</button></form></body></html>`)
+	_, _ = w.Write([]byte(b.String()))
+}

--- a/internal/handler/dashboard_page_test.go
+++ b/internal/handler/dashboard_page_test.go
@@ -1,0 +1,72 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/web"
+)
+
+func TestDashboardPage_ServesHTML(t *testing.T) {
+	h := DashboardPageHandler{
+		HTML:     web.DashboardHTML,
+		Password: "secret",
+		Secret:   []byte("test-secret-32-bytes-long!!!!!!"),
+	}
+	r := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	w := httptest.NewRecorder()
+	h.Page(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Fatalf("content-type=%q", ct)
+	}
+	if w.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("cache-control=%q", w.Header().Get("Cache-Control"))
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "API_TOKEN") || strings.Contains(body, "Authorization") {
+		t.Fatal("HTML must not contain API_TOKEN or Authorization")
+	}
+	if !strings.Contains(body, "/dashboard/data") {
+		t.Fatal("expected /dashboard/data endpoint")
+	}
+}
+
+func TestDashboardPage_NotConfigured(t *testing.T) {
+	h := DashboardPageHandler{HTML: []byte("x")}
+	r := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	w := httptest.NewRecorder()
+	h.Page(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d", w.Code)
+	}
+}
+
+func TestDashboardPage_LoginSetsCookie(t *testing.T) {
+	h := DashboardPageHandler{
+		HTML:     []byte("x"),
+		Password: "secret",
+		Secret:   []byte("test-secret-32-bytes-long!!!!!!"),
+	}
+	r := httptest.NewRequest(http.MethodPost, "/dashboard/login", strings.NewReader("password=secret"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.RemoteAddr = "127.0.0.1:1234"
+	w := httptest.NewRecorder()
+	h.LoginPost(w, r)
+	if w.Code != http.StatusFound {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	found := false
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "mk_staff" && c.Value != "" && c.HttpOnly && c.Path == "/dashboard" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected mk_staff cookie")
+	}
+}

--- a/internal/handler/golden_dashboard_test.go
+++ b/internal/handler/golden_dashboard_test.go
@@ -72,6 +72,16 @@ func TestGolden_Dashboard_Schedule_OK(t *testing.T) {
 	}
 }
 
+func TestGolden_Dashboard_Data_SameShapeAsSchedule(t *testing.T) {
+	// GET /dashboard/data reuses DashboardHandler.Schedule (staff cookie in router).
+	svc := &fakeDashboardSvc{}
+	h := DashboardHandler{Svc: svc, Now: dashboardNow}
+	r := httptest.NewRequest(http.MethodGet, "/dashboard/data?date=2026-06-26", nil)
+	w := httptest.NewRecorder()
+	h.Schedule(w, r)
+	assertGolden(t, "dashboard_schedule_ok", w.Body.Bytes())
+}
+
 func TestGolden_Dashboard_Schedule_EmptyDay(t *testing.T) {
 	h := DashboardHandler{Svc: &fakeDashboardSvcEmpty{}, Now: dashboardNow}
 	r := httptest.NewRequest(http.MethodGet, "/api/dashboard/schedule?date=2026-06-27", nil)

--- a/internal/middleware/cidr.go
+++ b/internal/middleware/cidr.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/response"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/staffsession"
+)
+
+// AllowCIDRs rejects requests whose RemoteAddr is outside the allowlist.
+type AllowCIDRs struct {
+	Nets []*net.IPNet
+}
+
+func ParseCIDRList(csv []string) ([]*net.IPNet, error) {
+	out := make([]*net.IPNet, 0, len(csv))
+	for _, raw := range csv {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		if !strings.Contains(raw, "/") {
+			ip := net.ParseIP(raw)
+			if ip == nil {
+				return nil, &net.ParseError{Type: "IP address", Text: raw}
+			}
+			bits := 32
+			if ip.To4() == nil {
+				bits = 128
+			}
+			raw = ip.String() + "/" + strconv.Itoa(bits)
+		}
+		_, n, err := net.ParseCIDR(raw)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+func (a AllowCIDRs) Allowed(ipStr string) bool {
+	if len(a.Nets) == 0 {
+		return true
+	}
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	for _, n := range a.Nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a AllowCIDRs) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := staffsession.ClientIP(r.RemoteAddr)
+		if !a.Allowed(ip) {
+			response.Error(w, http.StatusForbidden, "FORBIDDEN", "Доступ запрещён")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/middleware/staff.go
+++ b/internal/middleware/staff.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/response"
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/staffsession"
+)
+
+// RequireStaff checks the mk_staff session cookie.
+type RequireStaff struct {
+	Secret []byte
+	Now    func() time.Time
+}
+
+func (s RequireStaff) now() time.Time {
+	if s.Now != nil {
+		return s.Now()
+	}
+	return time.Now()
+}
+
+func (s RequireStaff) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := r.Cookie(staffsession.CookieName)
+		ok := err == nil && c != nil && staffsession.Valid(s.Secret, c.Value, s.now())
+		if !ok {
+			if strings.HasPrefix(r.URL.Path, "/dashboard/data") {
+				response.Error(w, http.StatusUnauthorized, "UNAUTHORIZED", "Требуется вход")
+				return
+			}
+			http.Redirect(w, r, "/dashboard/login", http.StatusFound)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/middleware/staff_test.go
+++ b/internal/middleware/staff_test.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/medkvadrat/medkvadrat-patient-api/internal/staffsession"
+)
+
+func TestAllowCIDRs(t *testing.T) {
+	nets, err := ParseCIDRList([]string{"192.168.0.0/16", "127.0.0.1/32"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := AllowCIDRs{Nets: nets}
+	if !a.Allowed("192.168.2.104") {
+		t.Fatal("lan should allow")
+	}
+	if !a.Allowed("127.0.0.1") {
+		t.Fatal("loopback should allow")
+	}
+	if a.Allowed("8.8.8.8") {
+		t.Fatal("public should deny")
+	}
+}
+
+func TestRequireStaff_RedirectAndJSON(t *testing.T) {
+	secret := []byte("test-secret-32-bytes-long!!!!!!")
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	staff := RequireStaff{Secret: secret, Now: func() time.Time { return now }}
+	okH := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	h := staff.Wrap(okH)
+
+	{
+		r := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusFound {
+			t.Fatalf("page without cookie: %d", w.Code)
+		}
+		if loc := w.Header().Get("Location"); loc != "/dashboard/login" {
+			t.Fatalf("location=%q", loc)
+		}
+	}
+	{
+		r := httptest.NewRequest(http.MethodGet, "/dashboard/data", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("data without cookie: %d", w.Code)
+		}
+	}
+	{
+		exp := now.Add(time.Hour)
+		r := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+		r.AddCookie(&http.Cookie{Name: staffsession.CookieName, Value: staffsession.Sign(secret, exp)})
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("valid cookie: %d", w.Code)
+		}
+	}
+}

--- a/internal/staffsession/session.go
+++ b/internal/staffsession/session.go
@@ -1,0 +1,67 @@
+package staffsession
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const CookieName = "mk_staff"
+
+// Sign returns a cookie value: expUnix|hex(HMAC-SHA256(secret, expUnix)).
+func Sign(secret []byte, exp time.Time) string {
+	payload := strconv.FormatInt(exp.Unix(), 10)
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte(payload))
+	return payload + "|" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// Valid reports whether value is a well-formed, unexpired, correctly signed session.
+func Valid(secret []byte, value string, now time.Time) bool {
+	parts := strings.Split(value, "|")
+	if len(parts) != 2 {
+		return false
+	}
+	payload, sigHex := parts[0], parts[1]
+	expUnix, err := strconv.ParseInt(payload, 10, 64)
+	if err != nil {
+		return false
+	}
+	if now.Unix() > expUnix {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte(payload))
+	want := mac.Sum(nil)
+	got, err := hex.DecodeString(sigHex)
+	if err != nil || len(got) != len(want) {
+		return false
+	}
+	return subtle.ConstantTimeCompare(got, want) == 1
+}
+
+// PasswordMatch compares candidate to expected using constant-time digest compare.
+func PasswordMatch(expected, candidate string) bool {
+	a := sha256.Sum256([]byte(expected))
+	b := sha256.Sum256([]byte(candidate))
+	return subtle.ConstantTimeCompare(a[:], b[:]) == 1
+}
+
+// ClientIP returns host from RemoteAddr (no X-Forwarded-For — trust only direct peer).
+func ClientIP(remoteAddr string) string {
+	host := remoteAddr
+	if i := strings.LastIndex(remoteAddr, ":"); i >= 0 {
+		// strip port; handle [ipv6]:port
+		h := remoteAddr[:i]
+		h = strings.Trim(h, "[]")
+		if h != "" {
+			host = h
+		}
+	}
+	return host
+}

--- a/internal/staffsession/session_test.go
+++ b/internal/staffsession/session_test.go
@@ -1,0 +1,60 @@
+package staffsession
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSignValid(t *testing.T) {
+	secret := []byte("test-secret-32-bytes-long!!!!!!")
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	exp := now.Add(12 * time.Hour)
+	val := Sign(secret, exp)
+	if !Valid(secret, val, now) {
+		t.Fatal("expected valid")
+	}
+	if Valid(secret, val, exp.Add(time.Second)) {
+		t.Fatal("expected expired")
+	}
+}
+
+func TestValidTampered(t *testing.T) {
+	secret := []byte("test-secret-32-bytes-long!!!!!!")
+	now := time.Now().UTC()
+	val := Sign(secret, now.Add(time.Hour))
+	// flip last hex nibble
+	bad := val[:len(val)-1] + "0"
+	if bad == val {
+		bad = val[:len(val)-1] + "1"
+	}
+	if Valid(secret, bad, now) {
+		t.Fatal("tampered cookie must fail")
+	}
+	if Valid([]byte("other-secret"), val, now) {
+		t.Fatal("wrong secret must fail")
+	}
+	if Valid(secret, "not-a-cookie", now) {
+		t.Fatal("garbage must fail")
+	}
+}
+
+func TestPasswordMatch(t *testing.T) {
+	if !PasswordMatch("secret", "secret") {
+		t.Fatal("equal")
+	}
+	if PasswordMatch("secret", "wrong") {
+		t.Fatal("mismatch")
+	}
+	if PasswordMatch("secret", "secre") {
+		t.Fatal("different length")
+	}
+}
+
+func TestClientIP(t *testing.T) {
+	if got := ClientIP("192.168.1.5:54321"); got != "192.168.1.5" {
+		t.Fatalf("got %q", got)
+	}
+	if got := ClientIP("[::1]:80"); got != "::1" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -1,0 +1,365 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>МедКвадрат — расписание филиалов</title>
+<style>
+  :root{
+    --ink:#0F1E1C;
+    --paper:#EEF1EE;
+    --surface:#FFFFFF;
+    --brand:#0E4F45;
+    --brand-soft:#E4EFEC;
+    --line:#D5DBD7;
+    --line-soft:#E7EBE8;
+    --muted:#6B7670;
+
+    --ok:#1E7A4C;
+    --ok-bg:#E6F4EC;
+    --no:#B3261E;
+    --no-bg:#FBEAE9;
+    --move:#9A6100;
+    --move-bg:#FBF0DC;
+    --wait:#71797A;
+    --wait-bg:#EDEFEF;
+
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,"Roboto Mono","DejaVu Sans Mono",monospace;
+    --ui:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  }
+
+  *{box-sizing:border-box}
+  html,body{height:100%}
+  body{
+    margin:0;background:var(--paper);color:var(--ink);
+    font-family:var(--ui);
+    display:flex;flex-direction:column;
+    -webkit-font-smoothing:antialiased;
+  }
+
+  /* ---------- шапка ---------- */
+  .top{
+    background:var(--brand);color:#fff;
+    padding:10px 18px;
+    display:flex;align-items:center;gap:18px;flex-wrap:wrap;
+  }
+  .brand{
+    font-size:15px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;
+    white-space:nowrap;
+  }
+  .brand span{opacity:.62;font-weight:500;letter-spacing:.08em;margin-left:10px}
+  .top-right{margin-left:auto;display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+  .clock{font-family:var(--mono);font-size:22px;font-weight:600;letter-spacing:.02em;font-variant-numeric:tabular-nums}
+  .live{display:flex;align-items:center;gap:7px;font-size:12px;opacity:.85}
+  .dot{width:8px;height:8px;border-radius:50%;background:#7BE0A8;animation:pulse 2s ease-in-out infinite}
+  .dot.stale{background:#FFC46B;animation:none}
+  .dot.down{background:#FF8A80;animation:none}
+  @keyframes pulse{0%,100%{opacity:1}50%{opacity:.25}}
+
+  input[type=date]{
+    font:inherit;font-size:13px;padding:5px 8px;border-radius:6px;
+    border:1px solid rgba(255,255,255,.35);background:rgba(255,255,255,.12);color:#fff;
+  }
+  input[type=date]::-webkit-calendar-picker-indicator{filter:invert(1);opacity:.7;cursor:pointer}
+  .btn{
+    font:inherit;font-size:13px;padding:6px 12px;border-radius:6px;cursor:pointer;
+    border:1px solid rgba(255,255,255,.35);background:transparent;color:#fff;
+  }
+  .btn:hover{background:rgba(255,255,255,.14)}
+  :focus-visible{outline:2px solid #7BE0A8;outline-offset:2px}
+
+  /* ---------- баннер состояния ---------- */
+  .banner{
+    display:none;padding:8px 18px;font-size:13px;
+    background:#FBF0DC;color:#6B4A00;border-bottom:1px solid #E8D9B4;
+  }
+  .banner.show{display:block}
+
+  /* ---------- сетка филиалов ---------- */
+  .board{
+    flex:1;display:grid;grid-template-columns:repeat(3,1fr);
+    gap:1px;background:var(--line);min-height:0;
+  }
+  .col{background:var(--paper);display:flex;flex-direction:column;min-height:0}
+
+  .col-head{
+    padding:12px 16px 10px;background:var(--surface);border-bottom:1px solid var(--line);
+  }
+  .col-name{font-size:17px;font-weight:650;letter-spacing:-.01em}
+  .col-addr{font-size:12px;color:var(--muted);margin-top:2px}
+  .col-stats{display:flex;gap:14px;margin-top:9px;font-size:12px;font-variant-numeric:tabular-nums}
+  .stat b{font-family:var(--mono);font-weight:600;font-size:13px}
+  .stat.ok b{color:var(--ok)} .stat.no b{color:var(--no)}
+  .stat.move b{color:var(--move)} .stat.wait b{color:var(--wait)}
+
+  .list{flex:1;overflow-y:auto;padding:8px 10px 24px;min-height:0;scrollbar-width:thin}
+
+  /* ---------- карточка приёма ---------- */
+  .row{
+    display:grid;grid-template-columns:56px 1fr;gap:10px;align-items:start;
+    background:var(--surface);border:1px solid var(--line-soft);border-left:4px solid var(--wait);
+    border-radius:7px;padding:8px 10px;margin-bottom:6px;
+    transition:background-color .8s ease;
+  }
+  .row.past{opacity:.42}
+  .row.confirmed{border-left-color:var(--ok)}
+  .row.declined{border-left-color:var(--no)}
+  .row.reschedule{border-left-color:var(--move)}
+  .row.fresh{background:var(--brand-soft);border-color:#BFD9D2}
+  @media (prefers-reduced-motion:no-preference){
+    .row.fresh{animation:flash 1.1s ease-out}
+  }
+  @keyframes flash{0%{transform:translateX(3px)}60%{transform:none}}
+
+  .time{font-family:var(--mono);font-size:15px;font-weight:600;font-variant-numeric:tabular-nums;padding-top:1px}
+  .who{min-width:0}
+  .patient{font-size:14px;font-weight:550;line-height:1.25;word-break:break-word}
+  .doctor{font-size:12px;color:var(--muted);margin-top:2px;word-break:break-word}
+  .tagline{display:flex;align-items:center;gap:6px;margin-top:6px;flex-wrap:wrap}
+  .pill{font-size:11px;padding:2px 8px;border-radius:999px;white-space:nowrap;font-weight:550}
+  .pill.confirmed{background:var(--ok-bg);color:var(--ok)}
+  .pill.declined{background:var(--no-bg);color:var(--no)}
+  .pill.reschedule{background:var(--move-bg);color:var(--move)}
+  .pill.pending{background:var(--wait-bg);color:var(--wait)}
+  .via{font-size:10px;color:var(--muted);letter-spacing:.06em;text-transform:uppercase}
+
+  /* ---------- линия «сейчас» ---------- */
+  .now{display:flex;align-items:center;gap:8px;margin:10px 2px 12px}
+  .now::before,.now::after{content:"";height:2px;background:var(--brand);flex:1;opacity:.55}
+  .now span{
+    font-family:var(--mono);font-size:11px;font-weight:700;color:var(--brand);
+    letter-spacing:.1em;white-space:nowrap;
+  }
+
+  .empty{padding:26px 8px;text-align:center;color:var(--muted);font-size:13px;line-height:1.5}
+
+  @media (max-width:900px){
+    .board{grid-template-columns:1fr;gap:0}
+    .col{border-bottom:1px solid var(--line)}
+    .list{overflow:visible;padding-bottom:10px}
+    body{height:auto}
+  }
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="brand">МедКвадрат <span>расписание филиалов</span></div>
+  <div class="top-right">
+    <input type="date" id="date" aria-label="Дата расписания">
+    <button class="btn" id="today">Сегодня</button>
+    <div class="live"><span class="dot" id="dot"></span><span id="liveText">подключение…</span></div>
+    <div class="clock" id="clock">--:--:--</div>
+  </div>
+</header>
+
+<div class="banner" id="banner" role="status"></div>
+
+<main class="board" id="board"></main>
+
+<script>
+// ─────────── настройки ───────────
+const CONFIG = {
+  // Same-origin + staff session cookie (mk_staff). No bearer token in the browser.
+  API_BASE: '',
+  ENDPOINT: '/dashboard/data',
+  POLL_MS: 10000,     // как часто опрашиваем расписание
+  FRESH_MS: 6000,     // сколько подсвечивать изменившуюся запись
+  STALE_MS: 35000     // после этого данные считаем устаревшими
+};
+
+const ADDRESSES = {
+  106: 'Каширское шоссе, 74к1',
+  3:   'ул. Ландышевая, 14к1',
+  496: 'ул. Воротынская, 4'
+};
+
+const LABEL = {
+  confirmed:  'придёт',
+  declined:   'не придёт',
+  reschedule: 'нужен перенос',
+  pending:    'без ответа'
+};
+
+// ─────────── состояние ───────────
+let lastSeen = new Map();   // planning_id -> confirmation (для диффа)
+let freshUntil = new Map(); // planning_id -> timestamp
+let lastOkAt = 0;
+let timer = null;
+
+const $ = id => document.getElementById(id);
+const board = $('board'), banner = $('banner'), dot = $('dot'), liveText = $('liveText');
+
+// ─────────── дата и часы ───────────
+const msk = d => new Date(d.toLocaleString('en-US', {timeZone: 'Europe/Moscow'}));
+const todayISO = () => {
+  const d = msk(new Date());
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+};
+$('date').value = todayISO();
+
+setInterval(() => {
+  const d = msk(new Date());
+  $('clock').textContent = d.toTimeString().slice(0,8);
+  renderStaleness();
+}, 1000);
+
+// ─────────── запрос ───────────
+async function load() {
+  const date = $('date').value || todayISO();
+  const url = `${CONFIG.API_BASE}${CONFIG.ENDPOINT}?date=${encodeURIComponent(date)}`;
+
+  try {
+    const res = await fetch(url, {credentials: 'same-origin'});
+    if (res.status === 401 || res.status === 403) {
+      window.location.href = '/dashboard/login';
+      return;
+    }
+    if (!res.ok) throw new Error(`сервер ответил ${res.status}`);
+
+    const body = await res.json();
+    if (!body.success) throw new Error(body.error || 'сервер вернул ошибку');
+
+    lastOkAt = Date.now();
+    hideBanner();
+    render(body.data);
+  } catch (err) {
+    showBanner(`Не удалось обновить расписание: ${err.message}. Показаны последние полученные данные.`);
+  }
+}
+
+// ─────────── отрисовка ───────────
+function render(data) {
+  const branches = data.branches || [];
+  const isToday = (data.date || $('date').value) === todayISO();
+  const nowMin = minutesNow();
+
+  // диффим подтверждения, чтобы подсветить изменения (в т.ч. пришедшие из MAX)
+  const seenNow = new Map();
+  branches.forEach(b => (b.appointments || []).forEach(a => {
+    const key = a.planning_id;
+    const val = a.confirmation || 'pending';
+    seenNow.set(key, val);
+    if (lastSeen.size && lastSeen.has(key) && lastSeen.get(key) !== val) {
+      freshUntil.set(key, Date.now() + CONFIG.FRESH_MS);
+    }
+  }));
+  lastSeen = seenNow;
+
+  board.innerHTML = '';
+  branches.forEach(b => board.appendChild(renderBranch(b, isToday, nowMin)));
+}
+
+function renderBranch(branch, isToday, nowMin) {
+  const items = branch.appointments || [];
+  const counts = {confirmed:0, declined:0, reschedule:0, pending:0};
+  items.forEach(a => counts[a.confirmation || 'pending']++);
+
+  const col = el('section', 'col');
+  const head = el('div', 'col-head');
+  head.appendChild(el('div', 'col-name', branch.name || branch.branch_code || '—'));
+  head.appendChild(el('div', 'col-addr', ADDRESSES[branch.branch_id] || ''));
+
+  const stats = el('div', 'col-stats');
+  stats.appendChild(stat('ok',   counts.confirmed,  'придут'));
+  stats.appendChild(stat('wait', counts.pending,    'молчат'));
+  stats.appendChild(stat('move', counts.reschedule, 'перенос'));
+  stats.appendChild(stat('no',   counts.declined,   'откажутся'));
+  head.appendChild(stats);
+  col.appendChild(head);
+
+  const list = el('div', 'list');
+  if (!items.length) {
+    list.appendChild(el('div', 'empty', 'На этот день записей нет.'));
+  } else {
+    let nowDrawn = false;
+    items.forEach(a => {
+      const mins = toMinutes(a.time);
+      if (isToday && !nowDrawn && mins > nowMin) {
+        list.appendChild(nowLine());
+        nowDrawn = true;
+      }
+      list.appendChild(renderRow(a, isToday && mins <= nowMin));
+    });
+    if (isToday && !nowDrawn) list.appendChild(nowLine());
+  }
+  col.appendChild(list);
+  return col;
+}
+
+function renderRow(a, isPast) {
+  const state = a.confirmation || 'pending';
+  const row = el('article', `row ${state}`);
+  if (isPast) row.classList.add('past');
+  if ((freshUntil.get(a.planning_id) || 0) > Date.now()) row.classList.add('fresh');
+
+  row.appendChild(el('div', 'time', a.time || '--:--'));
+
+  const who = el('div', 'who');
+  who.appendChild(el('div', 'patient', a.patient_name || 'Без имени'));
+  if (a.doctor_name) who.appendChild(el('div', 'doctor', a.doctor_name));
+
+  const tags = el('div', 'tagline');
+  tags.appendChild(el('span', `pill ${state}`, LABEL[state]));
+  if (state !== 'pending') tags.appendChild(el('span', 'via', 'ответ из MAX'));
+  who.appendChild(tags);
+
+  row.appendChild(who);
+  return row;
+}
+
+function nowLine() {
+  const wrap = el('div', 'now');
+  wrap.appendChild(el('span', '', `СЕЙЧАС ${msk(new Date()).toTimeString().slice(0,5)}`));
+  return wrap;
+}
+
+// ─────────── мелочи ───────────
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text !== undefined) n.textContent = text;
+  return n;
+}
+function stat(kind, value, label) {
+  const s = el('span', `stat ${kind}`);
+  s.appendChild(el('b', '', value));
+  s.appendChild(document.createTextNode(' ' + label));
+  return s;
+}
+const toMinutes = t => {
+  const [h, m] = String(t || '0:0').split(':').map(Number);
+  return (h || 0) * 60 + (m || 0);
+};
+function minutesNow() {
+  const d = msk(new Date());
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+function renderStaleness() {
+  if (!lastOkAt) return;
+  const age = Date.now() - lastOkAt;
+  if (age < CONFIG.STALE_MS) {
+    dot.className = 'dot';
+    liveText.textContent = 'обновляется';
+  } else if (age < CONFIG.STALE_MS * 3) {
+    dot.className = 'dot stale';
+    liveText.textContent = `данные от ${new Date(lastOkAt).toTimeString().slice(0,8)}`;
+  } else {
+    dot.className = 'dot down';
+    liveText.textContent = 'нет связи с сервером';
+  }
+}
+function showBanner(msg){ banner.textContent = msg; banner.classList.add('show'); }
+function hideBanner(){ banner.classList.remove('show'); }
+
+// ─────────── управление ───────────
+$('date').addEventListener('change', load);
+$('today').addEventListener('click', () => { $('date').value = todayISO(); load(); });
+document.addEventListener('visibilitychange', () => { if (!document.hidden) load(); });
+
+load();
+timer = setInterval(load, CONFIG.POLL_MS);
+</script>
+</body>
+</html>

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,6 @@
+package web
+
+import _ "embed"
+
+//go:embed dashboard.html
+var DashboardHTML []byte


### PR DESCRIPTION
## Summary
- Serve embedded `web/dashboard.html` at `GET /dashboard` with staff session cookie (`mk_staff` HMAC), login/logout, CIDR allowlist, and login rate limit.
- `GET /dashboard/data` reuses the same schedule handler as `/api/dashboard/schedule` (no SQL duplication, no bearer token in the browser).
- Config: `DASHBOARD_PASSWORD`, `DASHBOARD_SECRET`, TTL, cookie Secure flag, allowed CIDRs. Documented in README / `.env.example` (stand `192.168.2.104`).

## Security
- [x] `API_TOKEN` not in HTML/JS (token gate removed; 401 → `/dashboard/login`)
- [x] Password/cookie/secret/FIO not logged
- [x] Medialog still read-only; no new DB writes

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [ ] On stand: set dashboard env, open `/dashboard/login`, confirm schedule poll via cookie